### PR TITLE
Ensure revision correspondence of config file and git tag

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^pkgdown$
 ^\.pre-commit-config\.yaml$
 ^API$
+^inst/consistent_release_tag.sh$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,10 @@ repos:
     rev: v2.4.0
     hooks: 
     -   id: check-added-large-files
+-   repo: local
+    hooks:
+    -   id: consistent_release_tag
+        name: consistent_release_tag
+        entry: 
+        language: script
+        stages: ["push"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
     rev: v0.0.0.9026
+    default_stages: [push]
     hooks: 
     # any R project
     -   id: style-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 # All available hooks: https://pre-commit.com/hooks.html
+# R specific hooks: https://github.com/lorenzwalthert/precommit
 default_stages: ["commit"]
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.0.0.9026
+    rev: v0.0.0.9027
     hooks: 
     # any R project
     -   id: style-files
@@ -25,4 +26,4 @@ repos:
         name: consistent_release_tag
         entry: inst/consistent_release_tag
         language: script
-        stages: ["push"]
+        stages: ["commit", "push"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
     hooks:
     -   id: consistent_release_tag
         name: consistent_release_tag
-        entry: inst/consistent_release_tag.sh
+        entry: inst/consistent_release_tag
         language: script
         stages: ["push"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 # All available hooks: https://pre-commit.com/hooks.html
+default_stages: ["commit"]
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
     rev: v0.0.0.9026
-    default_stages: [push]
     hooks: 
     # any R project
     -   id: style-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # All available hooks: https://pre-commit.com/hooks.html
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.0.0.9025
+    rev: v0.0.0.9026
     hooks: 
     # any R project
     -   id: style-files
@@ -22,6 +22,6 @@ repos:
     hooks:
     -   id: consistent_release_tag
         name: consistent_release_tag
-        entry: 
+        entry: inst/consistent_release_tag.sh
         language: script
         stages: ["push"]

--- a/README.Rmd
+++ b/README.Rmd
@@ -6,7 +6,7 @@ output: github_document
 
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
-  fig.path = "man/figures/", 
+  fig.path = "man/figures/",
   eval = FALSE
 )
 ```
@@ -95,7 +95,7 @@ To update the hook revisions, run `precommit::autoupdate()`.
   installed, you might get this error:
 
 ```{r}
-#> Error in loadNamespace(name) : there is no package called ‘__name_of_package__’
+# > Error in loadNamespace(name) : there is no package called ‘__name_of_package__’
 ```
   In that case, just install the package with `install.packages()` once and 
   try to commit again.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To update the hook revisions, run `precommit::autoupdate()`.
 <!-- end list -->
 
 ``` r
-#> Error in loadNamespace(name) : there is no package called ‘__name_of_package__’
+# > Error in loadNamespace(name) : there is no package called ‘__name_of_package__’
 ```
 
 In that case, just install the package with `install.packages()` once

--- a/inst/consistent_release_tag
+++ b/inst/consistent_release_tag
@@ -1,6 +1,5 @@
 #!/usr/bin/env Rscript
 
-
 path_config <- c(
   fs::path("inst", "pre-commit-config.yaml"),
   fs::path(".pre-commit-config.yaml")

--- a/inst/consistent_release_tag
+++ b/inst/consistent_release_tag
@@ -1,4 +1,3 @@
-#!/usr/bin/env Rscript
 
 path_config <- c(
   fs::path("inst", "pre-commit-config.yaml"),
@@ -14,8 +13,8 @@ assert_config_has_rev <- function(path_config) {
   stopifnot(length(lorenzwalthert_precommit_idx) == 1)
   rev <- file$repos[[lorenzwalthert_precommit_idx]]$rev
   
-  latest_tag <- names(git2r::tags(".")[1])
-  
+  tags <- names(git2r::tags("."))
+  latest_tag <- max(as.numeric_version(gsub("^v", "", names(tags))))
   
   if (latest_tag != rev) {
     rlang::abort(glue::glue(

--- a/inst/consistent_release_tag
+++ b/inst/consistent_release_tag
@@ -1,5 +1,7 @@
 #!/usr/bin/env Rscript
 
+# This hook checks that all versions in config files and the git tag that
+# is used by precommit to clone the repo is identical.
 path_config <- c(
   fs::path("inst", "pre-commit-config.yaml"),
   fs::path(".pre-commit-config.yaml")

--- a/inst/consistent_release_tag
+++ b/inst/consistent_release_tag
@@ -1,3 +1,4 @@
+#!/usr/bin/env Rscript
 
 path_config <- c(
   fs::path("inst", "pre-commit-config.yaml"),
@@ -14,7 +15,7 @@ assert_config_has_rev <- function(path_config) {
   rev <- file$repos[[lorenzwalthert_precommit_idx]]$rev
   
   tags <- names(git2r::tags("."))
-  latest_tag <- max(as.numeric_version(gsub("^v", "", names(tags))))
+  latest_tag <- paste0("v", max(as.numeric_version(gsub("^v", "", tags))))
   
   if (latest_tag != rev) {
     rlang::abort(glue::glue(

--- a/inst/consistent_release_tag.sh
+++ b/inst/consistent_release_tag.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env Rscript
+
+
+path_config <- c(
+  fs::path("inst", "pre-commit-config.yaml"),
+  fs::path(".pre-commit-config.yaml")
+)
+
+
+assert_config_has_rev <- function(path_config) {
+  file <- yaml::read_yaml(path_config) 
+  repo <- purrr::map(file$repos, "repo") 
+  
+  lorenzwalthert_precommit_idx <- which(repo == "https://github.com/lorenzwalthert/precommit")
+  stopifnot(length(lorenzwalthert_precommit_idx) == 1)
+  rev <- file$repos[[lorenzwalthert_precommit_idx]]$rev
+  
+  latest_tag <- names(git2r::tags(".")[1])
+  
+  
+  if (latest_tag != rev) {
+    rlang::abort(glue::glue(
+      "latest git tag is `{latest_tag}`, but in `{path_config}`, you the  ", 
+      "revision is set to `{rev}` Please make the two correspond."
+    ))
+  }
+}
+
+purrr::walk(path_config, assert_config_has_rev)

--- a/inst/pre-commit-config.yaml
+++ b/inst/pre-commit-config.yaml
@@ -1,7 +1,8 @@
 # All available hooks: https://pre-commit.com/hooks.html
+# R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.0.0.9026
+    rev: v0.0.0.9027
     hooks: 
     # any R project
     -   id: style-files


### PR DESCRIPTION
Closes #18, although not automatically creating the releases in CI, but make sure when we push, the tags work.