### PR TITLE
Issue 92

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
 Suggests: 
     desc,
     git2r,
+    glue,
     knitr,
     lintr,
     oneliner (>= 0.1.0),

--- a/R/setup.R
+++ b/R/setup.R
@@ -40,20 +40,19 @@ use_precommit <- function(force = FALSE,
       ))
     }
     install_repo()
-    use_precommit_config(force)
-    autoupdate()
+    use_precommit_config(force, path_root)
+    autoupdate(path_root)
     if (open) {
-      open_config()
+      open_config(path_root)
     }
   })
 }
 
-use_precommit_config <- function(force) {
+use_precommit_config <- function(force, path_root = here::here()) {
   name_origin <- "pre-commit-config.yaml"
   escaped_name_target <- "^\\.pre-commit-config\\.yaml$"
   name_target <- ".pre-commit-config.yaml"
   # workaround for RCMD CHECK warning about hidden top-level directories.
-  path_root <- getwd()
   if (!fs::file_exists(fs::path(name_target)) | force) {
     fs::file_copy(
       system.file(name_origin, package = "precommit"),
@@ -68,7 +67,7 @@ use_precommit_config <- function(force) {
       ". Use `force = TRUE` to replace .pre-commit-config.yaml"
     ))
   }
-
+  
   if (is_package(".")) {
     usethis::write_union(".Rbuildignore", escaped_name_target)
   }

--- a/vignettes/hook-arguments.Rmd
+++ b/vignettes/hook-arguments.Rmd
@@ -13,7 +13,7 @@ arguments for the `style-files` hook can be set like this:
 
 ```{r, echo = FALSE, output = "asis", comment = ""}
 library(magrittr)
-config <- yaml::read_yaml(here::here(".pre-commit-config.yaml"))
+config <- yaml::read_yaml(system.file("pre-commit-config.yaml", package = "precommit", mustWork = TRUE))
 rev <- purrr::imap(config$repos, function(x, y) {
   if (x$repo == "https://github.com/lorenzwalthert/precommit") {
     return(x$rev)


### PR DESCRIPTION
This PR resolves issue #92 

- path_root parameter is passed down inside the `use_precommit` function
- without the glue package in Suggests the `devtools::check` finished with the following note
>checking for unstated dependencies in vignettes ... NOTE
  '::' or ':::' import not declared from: ‘glue’
- reading config file from the root folder instead of the one that is installed from inst resulted in the following warning
> checking re-building of vignette outputs ... WARNING
  Error in re-building vignettes:
    ...
  Quitting from lines 15-32 (hook-arguments.Rmd) 
  Error: processing vignette 'hook-arguments.Rmd' failed with diagnostics:
  cannot open the connection
  Execution halted

I've tried to figure out why the following test didn't catch the bug
https://github.com/lorenzwalthert/precommit/blob/master/tests/testthat/test-conda.R#L1-L14

When run as a whole block of code it succeeds. Running `here::here()` after the test returns the path to the tempdir.
However if you stick a `here::here()` call somewhere between the lines of this test then it fails with the error I got since it sticks to the working directory.
I guess by having multiple functions calling `here::here()` in project creating and git initializing workflow one could find himself unexpectedly in a wrong place due to the rules that apply to this function.

Now calling `here::here()` after running this test always returns the working directory.