### PR TITLE
Use more thoughtful order for hooks, between pkg and project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: deps-in-desc
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]
-    -   id: roxygenize # before spell check
+    -   id: roxygenize # spell-check needs up-to date doc.
     -   id: spell-check
     -   id: use-tidy-description
 -   repo: https://github.com/pre-commit/pre-commit-hooks
@@ -19,7 +19,7 @@ repos:
     hooks: 
     -   id: check-added-large-files
     -   id: end-of-file-fixer
-        exclude: '\.Rd'
+        exclude: '\.Rd' # sometimes roxygen fails to generate EOF blank line.
 -   repo: local
     hooks:
     -   id: consistent-release-tag

--- a/R/config.R
+++ b/R/config.R
@@ -1,22 +1,21 @@
 #' Initiate a pre-commit config file
 #'
-#' @param path_cp_config_from Path or URL to a `.pre-commit-config.yaml`. This config file
-#'   will be hard-copied into `path_root`. If `NULL`, we use
-#'   a default config from the path returned by
-#'   `system.file("pre-commit-config.yaml", package = "precommit")`. See
-#'   section 'Copying an existing config file'.
+#' @param path_cp_config_from Path or URL to a `.pre-commit-config.yaml`. This
+#'   config file will be hard-copied into `path_root`. If `NULL`, we check if
+#'   `path_root` is a package or project directory using
+#'   [rprojroot::find_package_root_file()], and resort to an appropriate default
+#'   config. See section 'Copying an existing config file'.
 #' @param force Whether to replace an existing config file.
 #' @param open Whether or not to open the .pre-commit-config.yaml after
 #'   it's been placed in your repo. The default is `TRUE` when working in
 #'   RStudio. Otherwise, we recommend manually inspecting the file.
 #' @param verbose Whether or not to communicate what's happening.
 #' @section Copying an existing config file:
-#' You can use an existing `.pre-commit-config.yaml` file when intiializing
-#' pre-commit with [use_precommit()] using the argument `path_cp_config_from` to copy
-#' an existing config file into your repo. This argument
-#' defaults to the R option `precommit.path_cp_config_from`, so you may want to
-#' set this option in your `.Rprofile` for convenience.
-#' Note that this is **not** equivalent
+#' You can use an existing `.pre-commit-config.yaml` file when initializing
+#' pre-commit with [use_precommit()] using the argument `path_cp_config_from` to
+#' copy an existing config file into your repo. This argument defaults to the R
+#' option `precommit.path_cp_config_from`, so you may want to set this option in
+#' your `.Rprofile` for convenience. Note that this is **not** equivalent
 #' to the `--config` option in the CLI command `pre-commit install` and similar,
 #' which do *not* copy a config file into a project root (and allow to put it
 #' under version control), but rather link it in some more or less transparent
@@ -30,6 +29,7 @@ use_precommit_config <- function(path_cp_config_from = getOption("precommit.path
                                  verbose = FALSE) {
   path_cp_config_from <- set_path_cp_config_from(
     path_cp_config_from,
+    path_root = path_root,
     verbose = verbose
   )
   escaped_name_target <- "^\\.pre-commit-config\\.yaml$"
@@ -49,7 +49,7 @@ use_precommit_config <- function(path_cp_config_from = getOption("precommit.path
     ))
   }
 
-  if (is_package(".")) {
+  if (is_package(path_root)) {
     usethis::write_union(".Rbuildignore", escaped_name_target)
   }
   usethis::ui_todo(c(
@@ -65,10 +65,12 @@ use_precommit_config <- function(path_cp_config_from = getOption("precommit.path
 #'
 #' If a remote location is specified, the file is downloaded to a temporary
 #' location and the path to this location is returned. If `NULL`, we'll resort
-#' to a default config. We'll perform some checks on the existance of the file
+#' to a default config. We'll perform some checks on the existence of the file
 #' too.
 #' @keywords internal
-set_path_cp_config_from <- function(path_cp_config_from, verbose = TRUE) {
+set_path_cp_config_from <- function(path_cp_config_from,
+                                    path_root,
+                                    verbose = TRUE) {
   if (is_url(path_cp_config_from)) {
     if (verbose) {
       usethis::ui_info("Downloading remote config from {path_cp_config_from}.")
@@ -90,7 +92,10 @@ set_path_cp_config_from <- function(path_cp_config_from, verbose = TRUE) {
   }
   if (is.null(path_cp_config_from)) {
     # workaround for R CMD CHECK warning about hidden top-level directories.
-    name_origin <- "pre-commit-config.yaml"
+    name_origin <- ifelse(is_package(path_root),
+      "pre-commit-config-pkg.yaml",
+      "pre-commit-config-proj.yaml"
+    )
     path_cp_config_from <- system.file(name_origin, package = "precommit")
   }
   if (!fs::file_exists(path_cp_config_from)) {

--- a/R/release.R
+++ b/R/release.R
@@ -23,7 +23,10 @@ release_gh <- function(bump = "dev") {
   }
   release_prechecks()
 
-  path_template_config <- "inst/pre-commit-config.yaml"
+  path_template_config <- c(
+    "inst/pre-commit-config-pkg.yaml",
+    "inst/pre-commit-config-proj.yaml"
+  )
 
   old_version <- paste0("v", desc::desc_get_version())
   dsc <- desc::description$new()
@@ -33,10 +36,12 @@ release_gh <- function(bump = "dev") {
   dsc$write()
   usethis::ui_done("Bumped version.")
 
-  update_rev_in_config(new_version, path_template_config)
+  purrr::walk(path_template_config, update_rev_in_config,
+    new_version = new_version
+  )
   usethis::ui_done("Updated version in default config.")
   msg <- glue::glue("Release {new_version}, see NEWS.md for details.")
-  sys_call("git", glue::glue('commit DESCRIPTION {path_template_config} -m "{msg}"'),
+  sys_call("git", glue::glue('commit DESCRIPTION {paste0(path_template_config, collapse = " ")} -m "{msg}"'),
     env = "SKIP=spell-check,consistent-release-tag"
   )
   usethis::ui_done("Committed DESCRIPTION and config template")

--- a/R/setup.R
+++ b/R/setup.R
@@ -13,7 +13,7 @@
 #' * You cloned a repo that has a `.pre-commit-config.yaml` already. You need
 #'   to make sure git calls the hooks before the next commit.
 #'
-#' @section What it does the funciton do?:
+#' @section What it does the function do?:
 #' * sets up pre-commit in your current directory with `$ pre-commit install`.
 #' * sets up a template `.pre-commit-config.yaml`.
 #' * autoupdates the template to make sure you get the latest versions of the

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,10 +1,3 @@
-is_package <- function(base_path = here::here()) {
-  res <- tryCatch(rprojroot::find_package_root_file(path = base_path),
-    error = function(e) NULL
-  )
-  !is.null(res)
-}
-
 is_windows <- function() {
   identical(.Platform$OS.type, "windows")
 }
@@ -23,4 +16,13 @@ is_url <- function(text) {
 path_if_exist <- function(...) {
   path <- c(...)
   path[fs::file_exists(path)]
+}
+
+is_package <- function(path_root = here::here()) {
+  rlang::with_handlers(
+    rprojroot::find_package_root_file(path = path_root),
+    error = function(e) NULL
+  ) %>%
+    is.null() %>%
+    magrittr::not()
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,5 +1,6 @@
 args
 autoupdate
+CLI
 cmd
 CMD
 codemeta
@@ -10,6 +11,8 @@ Ctrl
 deps
 desc
 dev
+docopt
+emph
 env
 EOF
 fs
@@ -17,9 +20,11 @@ getOption
 gh
 github
 gitignore
+gsub
 href
 https
 icloud
+idx
 impl
 isAvailable
 json
@@ -38,6 +43,8 @@ pkgdown
 pre
 precommit
 precommithooks
+proj
+purrr
 py
 readme
 repo
@@ -51,13 +58,17 @@ ropenscilabs
 roxygen
 roxygenize
 RoxygenNote
+Rprofile
+rprojroot
 rR
 Rr
 Rscript
 RStudio
 rstudioapi
+seealso
 stderr
 stdout
+stopifnot
 styler
 testthat
 tidyverse

--- a/inst/consistent-release-tag
+++ b/inst/consistent-release-tag
@@ -18,7 +18,8 @@ arguments <- docopt::docopt(doc)
 # - release new version on CRAN, make sure all tags correspond to 0.2.0.
 
 path_config <- c(
-  fs::path("inst", "pre-commit-config.yaml"),
+  fs::path("inst", "pre-commit-config-pkg.yaml"),
+  fs::path("inst", "pre-commit-config-proj.yaml"),
   if (!arguments$`release-mode`) fs::path(".pre-commit-config.yaml")
 )
 

--- a/inst/pre-commit-config-pkg.yaml
+++ b/inst/pre-commit-config-pkg.yaml
@@ -1,34 +1,25 @@
 # All available hooks: https://pre-commit.com/hooks.html
 # R specific hooks: https://github.com/lorenzwalthert/precommit
-default_stages: ["commit"]
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
     rev: v0.0.0.9038
     hooks: 
     -   id: parsable-R
     -   id: no-browser-statement
+    -   id: lintr
     -   id: readme-rmd-rendered
+    -   id: spell-check
     -   id: deps-in-desc
     -   id: style-files
-        args: [--style_pkg=styler, --style_fun=tidyverse_style]
-    -   id: roxygenize # before spell check
-    -   id: spell-check
+        args: [--style_pkg=styler, --style_fun=tidyverse_style]    
+    -   id: roxygenize
+    # codemeta must be above use-tidy-description when both are used
+    # -   id: codemeta-description-updated
     -   id: use-tidy-description
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v1.2.3
     hooks: 
     -   id: check-added-large-files
+        args: ['--maxkb=200']
     -   id: end-of-file-fixer
         exclude: '\.Rd'
--   repo: local
-    hooks:
-    -   id: consistent-release-tag
-        name: consistent-release-tag
-        entry: inst/consistent-release-tag
-        language: script
-        stages: [commit, push]
-    -   id: hooks-config-to-inst
-        name: hooks-config-to-inst
-        entry: inst/hooks-config-to-inst
-        language: script
-        stages: [commit, push]

--- a/inst/pre-commit-config-proj.yaml
+++ b/inst/pre-commit-config-proj.yaml
@@ -4,24 +4,17 @@ repos:
 -   repo: https://github.com/lorenzwalthert/precommit
     rev: v0.0.0.9038
     hooks: 
-    # any R project
-    -   id: style-files
-        args: [--style_pkg=styler, --style_fun=tidyverse_style]    
-    -   id: lintr
     -   id: parsable-R
     -   id: no-browser-statement
+    -   id: lintr
     -   id: readme-rmd-rendered
     -   id: spell-check
-    #  R package development
-    # the first hook below
-    # must be listed above use-tidy-description when both are used
-    # -   id: codemeta-description-updated
-    # -   id: roxygenize
-    # -   id: use-tidy-description
-    # -   id: deps-in-desc
+    -   id: style-files
+        args: [--style_pkg=styler, --style_fun=tidyverse_style]    
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.2.3
     hooks: 
     -   id: check-added-large-files
         args: ['--maxkb=200']
     -   id: end-of-file-fixer
+        exclude: '\.Rd'

--- a/man/set_path_cp_config_from.Rd
+++ b/man/set_path_cp_config_from.Rd
@@ -4,12 +4,12 @@
 \alias{set_path_cp_config_from}
 \title{Set the location to a config file}
 \usage{
-set_path_cp_config_from(path_cp_config_from, verbose = TRUE)
+set_path_cp_config_from(path_cp_config_from, path_root, verbose = TRUE)
 }
 \description{
 If a remote location is specified, the file is downloaded to a temporary
 location and the path to this location is returned. If \code{NULL}, we'll resort
-to a default config. We'll perform some checks on the existance of the file
+to a default config. We'll perform some checks on the existence of the file
 too.
 }
 \keyword{internal}

--- a/man/use_precommit.Rd
+++ b/man/use_precommit.Rd
@@ -12,11 +12,11 @@ use_precommit(
 )
 }
 \arguments{
-\item{path_cp_config_from}{Path or URL to a \code{.pre-commit-config.yaml}. This config file
-will be hard-copied into \code{path_root}. If \code{NULL}, we use
-a default config from the path returned by
-\code{system.file("pre-commit-config.yaml", package = "precommit")}. See
-section 'Copying an existing config file'.}
+\item{path_cp_config_from}{Path or URL to a \code{.pre-commit-config.yaml}. This
+config file will be hard-copied into \code{path_root}. If \code{NULL}, we check if
+\code{path_root} is a package or project directory using
+\code{\link[rprojroot:find_package_root_file]{rprojroot::find_package_root_file()}}, and resort to an appropriate default
+config. See section 'Copying an existing config file'.}
 
 \item{force}{Whether to replace an existing config file.}
 
@@ -41,7 +41,7 @@ to make sure git calls the hooks before the next commit.
 }
 }
 
-\section{What it does the funciton do?}{
+\section{What it does the function do?}{
 
 \itemize{
 \item sets up pre-commit in your current directory with \verb{$ pre-commit install}.
@@ -54,12 +54,11 @@ hooks.
 
 \section{Copying an existing config file}{
 
-You can use an existing \code{.pre-commit-config.yaml} file when intiializing
-pre-commit with \code{\link[=use_precommit]{use_precommit()}} using the argument \code{path_cp_config_from} to copy
-an existing config file into your repo. This argument
-defaults to the R option \code{precommit.path_cp_config_from}, so you may want to
-set this option in your \code{.Rprofile} for convenience.
-Note that this is \strong{not} equivalent
+You can use an existing \code{.pre-commit-config.yaml} file when initializing
+pre-commit with \code{\link[=use_precommit]{use_precommit()}} using the argument \code{path_cp_config_from} to
+copy an existing config file into your repo. This argument defaults to the R
+option \code{precommit.path_cp_config_from}, so you may want to set this option in
+your \code{.Rprofile} for convenience. Note that this is \strong{not} equivalent
 to the \code{--config} option in the CLI command \verb{pre-commit install} and similar,
 which do \emph{not} copy a config file into a project root (and allow to put it
 under version control), but rather link it in some more or less transparent

--- a/man/use_precommit_config.Rd
+++ b/man/use_precommit_config.Rd
@@ -13,11 +13,11 @@ use_precommit_config(
 )
 }
 \arguments{
-\item{path_cp_config_from}{Path or URL to a \code{.pre-commit-config.yaml}. This config file
-will be hard-copied into \code{path_root}. If \code{NULL}, we use
-a default config from the path returned by
-\code{system.file("pre-commit-config.yaml", package = "precommit")}. See
-section 'Copying an existing config file'.}
+\item{path_cp_config_from}{Path or URL to a \code{.pre-commit-config.yaml}. This
+config file will be hard-copied into \code{path_root}. If \code{NULL}, we check if
+\code{path_root} is a package or project directory using
+\code{\link[rprojroot:find_package_root_file]{rprojroot::find_package_root_file()}}, and resort to an appropriate default
+config. See section 'Copying an existing config file'.}
 
 \item{force}{Whether to replace an existing config file.}
 
@@ -34,12 +34,11 @@ Initiate a pre-commit config file
 }
 \section{Copying an existing config file}{
 
-You can use an existing \code{.pre-commit-config.yaml} file when intiializing
-pre-commit with \code{\link[=use_precommit]{use_precommit()}} using the argument \code{path_cp_config_from} to copy
-an existing config file into your repo. This argument
-defaults to the R option \code{precommit.path_cp_config_from}, so you may want to
-set this option in your \code{.Rprofile} for convenience.
-Note that this is \strong{not} equivalent
+You can use an existing \code{.pre-commit-config.yaml} file when initializing
+pre-commit with \code{\link[=use_precommit]{use_precommit()}} using the argument \code{path_cp_config_from} to
+copy an existing config file into your repo. This argument defaults to the R
+option \code{precommit.path_cp_config_from}, so you may want to set this option in
+your \code{.Rprofile} for convenience. Note that this is \strong{not} equivalent
 to the \code{--config} option in the CLI command \verb{pre-commit install} and similar,
 which do \emph{not} copy a config file into a project root (and allow to put it
 under version control), but rather link it in some more or less transparent

--- a/tests/testthat/test-conda.R
+++ b/tests/testthat/test-conda.R
@@ -36,7 +36,7 @@ test_that("can use custom config file ", {
   fs::dir_create(tempdir2)
   path_custom <- fs::path(tempdir2, "some-precommit.yaml")
   new_text <- "# 4js93"
-  readLines(system.file("pre-commit-config.yaml", package = "precommit")) %>%
+  readLines(system.file("pre-commit-config-proj.yaml", package = "precommit")) %>%
     c(new_text) %>%
     writeLines(path_custom)
   git2r::init(tempdir)

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -18,3 +18,22 @@ test_that("can set path to remote config", {
 
   expect_error(set_path_cp_config_from("https://apple.com"), "valid yaml")
 })
+
+test_that("defaults to right config depending on whether or not root is a pkg", {
+  tmp <- tempdir()
+  test.pkg <- fs::dir_create(tmp, "test.pkg")
+  withr::with_dir(test.pkg, {
+    desc <- desc::description$new("!new")
+    desc$set(Package = "test.pkg")
+    desc$write("DESCRIPTION")
+  })
+  expect_output(
+    set_path_cp_config_from(NULL, path_root = test.pkg),
+    "pkg\\.yaml"
+  )
+  fs::file_delete(fs::path(test.pkg, "DESCRIPTION"))
+  expect_output(
+    set_path_cp_config_from(NULL, path_root = test.pkg),
+    "proj\\.yaml"
+  )
+})

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -1,7 +1,9 @@
 test_that("can set path to local config", {
+  tmp <- tempdir()
+  test.pkg <- fs::dir_create(tmp, "test.proj")
   expect_equal(
-    set_path_cp_config_from(NULL),
-    system.file("pre-commit-config.yaml", package = "precommit")
+    set_path_cp_config_from(NULL, path_root = test.pkg),
+    system.file("pre-commit-config-proj.yaml", package = "precommit")
   )
   expect_error(
     set_path_cp_config_from(tempfile()),


### PR DESCRIPTION
Closes #142. First all read-only hooks, then all write and read hooks for speed.