### PR TITLE
Switch to env r-precommit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@ submission in #152:
 - `use_precommit_config`'s argument `verbose` now is in the same position as
   in `use_config()`.
 
+Additional breaking changes are:
+
+- use env `r-precommit` instead of `r-reticulate` to avoid conflicts with other 
+  packages commonly installed in `r-reticulate` (#147).
 
 # precommit v0.0.0.9040
 
@@ -22,8 +26,6 @@ submission in #152:
 - conda is a suggested dependency now, so those who choose a different 
   installation method have a more lightweight dependency graph (#136).
 - Use more thoughtful order for hooks, between pkg and project (#142).
-- use env `r-precommit` instead of `r-reticulate` to avoid conflicts with other 
-  packages commonly installed in `r-reticulate` (#147).
 
 # precommit v0.0.0.9031 up to v0.0.0.9038
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@ Test release process.
   config file into the repo at initialization. The argument defaults to 
   `options('precommit.config_source')` to make it easy for users to use 
   their preferred hooks in every repo they initialize (#111).
-- Create `r-reticulate` env if not existent before installing into it (#114).
+- Create `r-precommit` env if not existent before installing into it (#114).
 - Unify vignettes on available hooks and arguments (#109).
 - Fail fast when repo is not a git repo (#111).
 - default config file has spell-check activated (#118).

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@ submission in #152:
 - conda is a suggested dependency now, so those who choose a different 
   installation method have a more lightweight dependency graph (#136).
 - Use more thoughtful order for hooks, between pkg and project (#142).
+- use env `r-precommit` instead of `r-reticulate` to avoid conflicts with other 
+  packages commonly installed in `r-reticulate` (#147).
 
 # precommit v0.0.0.9031 up to v0.0.0.9038
 

--- a/R/call.R
+++ b/R/call.R
@@ -14,7 +14,7 @@ call_and_capture <- function(...) {
     system2(..., stdout = stdout, stderr = stderr)
   )
   stderr <- readLines(stderr)
-  if (isTRUE(grepl("error", stderr, ignore.case = TRUE))) {
+  if (isTRUE(any(grepl("error", stderr, ignore.case = TRUE)))) {
     # conda run has exit status 0 but stderr with ERROR, we need to set exit
     # code in that case.
     exit_status <- -999

--- a/R/call.R
+++ b/R/call.R
@@ -14,6 +14,12 @@ call_and_capture <- function(...) {
     system2(..., stdout = stdout, stderr = stderr)
   )
   stderr <- readLines(stderr)
+  if (isTRUE(grepl("error", stderr, ignore.case = TRUE))) {
+    # conda run has exit status 0 but stderr with ERROR, we need to set exit
+    # code in that case.
+    exit_status <- -999
+  }
+
   if (exit_status != 0) {
 
     if (length(stderr) < 1) {
@@ -28,6 +34,17 @@ call_and_capture <- function(...) {
     stderr = stderr,
     exit_status = exit_status
   )
+}
+
+call_precommit <- function(...) {
+  if (is_conda_installation()) {
+    call_and_capture(
+      reticulate::conda_binary(),
+      c("run", "-n", "r-precommit", path_precommit_exec(), ...)
+    )
+  } else {
+    call_and_capture(path_precommit_exec(), ...)
+  }
 }
 
 #' @param x The output of [call_and_capture()].

--- a/R/exec.R
+++ b/R/exec.R
@@ -108,7 +108,7 @@ path_derive_precommit_exec_path <- function() {
 
 #' Derive the path to the conda pre-commit executable
 #'
-#' Only checks the conda env `r-reticulate`.
+#' Only checks the conda env `r-precommit`.
 #' If we can't find the executable, the empty string is returned.
 #' @keywords internal
 path_derive_precommit_exec_conda <- function() {
@@ -116,7 +116,7 @@ path_derive_precommit_exec_conda <- function() {
     {
       ls <- reticulate::conda_list()
 
-      path_reticulate <- fs::path_dir(ls[ls$name == "r-reticulate", "python"][1])
+      path_reticulate <- fs::path_dir(ls[ls$name == "r-precommit", "python"][1])
       derived <- fs::path(
         path_reticulate,
         ifelse(is_windows(), "Scripts", ""),

--- a/R/install.R
+++ b/R/install.R
@@ -9,7 +9,7 @@ install_system <- function() {
   if (!is_installed()) {
     usethis::ui_info(paste(
       "Installing pre-commit into the conda environment",
-      "`r-reticulate`."
+      "`r-precommit`."
     ))
     install_impl()
     usethis::ui_done("Sucessfully installed pre-commit on your system.")
@@ -28,8 +28,8 @@ install_system <- function() {
 
 #' Install pre-commit on your system.
 #'
-#' This installs pre-commit in the conda environment r-reticulate. It
-#' will be available to use accross different git repositories.
+#' This installs pre-commit in the conda environment r-precommit. It
+#' will be available to use across different git repositories.
 #' @export
 install_precommit <- function() {
   install_system()
@@ -38,15 +38,15 @@ install_precommit <- function() {
 #' Install pre-commit on your system with conda
 #' @keywords internal
 install_impl <- function() {
-  if (!"r-reticulate" %in% reticulate::conda_list()$name) {
-    reticulate::conda_create("r-reticulate")
+  if (!"r-precommit" %in% reticulate::conda_list()$name) {
+    reticulate::conda_create("r-precommit")
   }
-  reticulate::conda_install(packages = "pre-commit")
+  reticulate::conda_install("r-precommit", packages = "pre-commit")
 }
 
 install_repo <- function(root) {
   withr::with_dir(root, {
-    out <- call_and_capture(path_precommit_exec(), "install")
+    out <- call_precommit("install")
     if (out$exit_status == 0) {
       usethis::ui_done("Sucessfully installed pre-commit for repo {fs::path_file(root)}.")
     } else {
@@ -63,7 +63,7 @@ install_repo <- function(root) {
 #' @param scope Either "repo" or "global". "repo" removes pre-commit from your
 #'   project, but you will be able to use it in other projects. With "global",
 #'   you remove the pre-commit executable in the virtual python environment
-#'   r-reticulate so it won't be available in any project. When you want to
+#'   r-precommit so it won't be available in any project. When you want to
 #'   remove pre-commit globally, you should remote it locally first.
 #' @param ask Either "global", "repo" or "none" to determine in which case
 #'   a prompt should show up to let the user confirm his action.
@@ -92,7 +92,7 @@ uninstall_system <- function(ask = TRUE) {
   if (is_installed()) {
     if (ask) {
       answer <- readline(paste(
-        "You are about to uninstall pre-commit from the conda env r-reticulate.",
+        "You are about to uninstall pre-commit from the conda env r-precommit.",
         "It won't be available to any git repo anymore. Do you want to",
         "proceed? You can re-install at any time later with",
         "`precommit::install_precommit()`.",
@@ -108,7 +108,7 @@ uninstall_system <- function(ask = TRUE) {
           "R option `precommit.executable` points to ",
           getOption("precommit.executable"),
           " from where we try to uninstall. ",
-          "Can only uninstall when installed with conda into env r-reticulate. ",
+          "Can only uninstall when installed with conda into env r-precommit. ",
           "Please remove pre-commit manually from the comamnd line. "
         ))
       } else {
@@ -117,10 +117,10 @@ uninstall_system <- function(ask = TRUE) {
         }
         out <- call_and_capture(
           reticulate::conda_binary(),
-          "remove -n r-reticulate pre-commit --yes"
+          "remove -n r-precommit pre-commit --yes"
         )
         if (out$exit_status == 0) {
-          usethis::ui_done("Removed pre-commit from conda env r-reticulate.")
+          usethis::ui_done("Removed pre-commit from conda env r-precommit.")
         } else {
           communicate_captured_call(out)
         }
@@ -149,7 +149,7 @@ uninstall_repo <- function(ask) {
     continue <- TRUE
   }
   if (continue) {
-    out <- call_and_capture(path_precommit_exec(), "uninstall")
+    out <- call_precommit("uninstall")
     if (out$exit_status == 0) {
       usethis::ui_done("Uninstalled pre-commit from repo scope.")
     } else {

--- a/R/setup.R
+++ b/R/setup.R
@@ -47,7 +47,7 @@ use_precommit <- function(config_source = getOption("precommit.config_source"),
 autoupdate <- function(root = here::here()) {
   withr::with_dir(root, {
     assert_correct_upstream_repo_url()
-    out <- call_and_capture(path_precommit_exec(), "autoupdate")
+    out <- call_precommit("autoupdate")
     if (out$exit_status == 0) {
       usethis::ui_done(paste0(
         "Ran `pre-commit autoupdate` to get the latest version of the hooks."

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,7 +20,7 @@ path_if_exist <- function(...) {
 
 is_conda_installation <- function() {
   grepl(
-    "conda3/envs/r-pre-commit/(bin|Scripts)/pre-commit(\\.exe)?",
+    "conda3/envs/r-precommit/(bin|Scripts)/pre-commit(\\.exe)?",
     getOption("precommit.executable")
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,7 +20,7 @@ path_if_exist <- function(...) {
 
 is_conda_installation <- function() {
   grepl(
-    "/envs/r-reticulate/(bin|Scripts)/pre-commit(\\.exe)?",
+    "conda3/envs/r-pre-commit/(bin|Scripts)/pre-commit(\\.exe)?",
     getOption("precommit.executable")
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,7 +20,7 @@ path_if_exist <- function(...) {
 
 is_conda_installation <- function() {
   grepl(
-    "conda3/envs/r-precommit/(bin|Scripts)/pre-commit(\\.exe)?",
+    "conda3?/envs/r-precommit/(bin|Scripts)/pre-commit(\\.exe)?",
     getOption("precommit.executable")
   )
 }

--- a/man/install_precommit.Rd
+++ b/man/install_precommit.Rd
@@ -7,6 +7,10 @@
 install_precommit()
 }
 \description{
+<<<<<<< HEAD
 This installs pre-commit in the conda environment r-precommit. It
+=======
+This installs pre-commit in the conda environment r-precommit It
+>>>>>>> switch to env r-precommit to avoid conflicts
 will be available to use across different git repositories.
 }

--- a/man/install_precommit.Rd
+++ b/man/install_precommit.Rd
@@ -7,6 +7,6 @@
 install_precommit()
 }
 \description{
-This installs pre-commit in the conda environment r-reticulate. It
-will be available to use accross different git repositories.
+This installs pre-commit in the conda environment r-precommit. It
+will be available to use across different git repositories.
 }

--- a/man/path_derive_precommit_exec_conda.Rd
+++ b/man/path_derive_precommit_exec_conda.Rd
@@ -7,7 +7,7 @@
 path_derive_precommit_exec_conda()
 }
 \description{
-Only checks the conda env \code{r-reticulate}.
+Only checks the conda env \code{r-precommit}.
 If we can't find the executable, the empty string is returned.
 }
 \keyword{internal}

--- a/man/uninstall_precommit.Rd
+++ b/man/uninstall_precommit.Rd
@@ -10,7 +10,7 @@ uninstall_precommit(scope = "repo", ask = "global", root = here::here())
 \item{scope}{Either "repo" or "global". "repo" removes pre-commit from your
 project, but you will be able to use it in other projects. With "global",
 you remove the pre-commit executable in the virtual python environment
-r-reticulate so it won't be available in any project. When you want to
+r-precommit so it won't be available in any project. When you want to
 remove pre-commit globally, you should remote it locally first.}
 
 \item{ask}{Either "global", "repo" or "none" to determine in which case

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -40,7 +40,7 @@ test_that("call capturing for error (command that does not exist)", {
 })
 
 test_that("call capturing for error fo command that exists (but arguments that don't)", {
-  expect_silent(captured <- call_and_capture(path_pre_commit_exec(), "hdif dijf"))
+  expect_silent(captured <- call_precommit("hdif dijf"))
   expect_true(
     captured$exit_status != 0
   )

--- a/vignettes/available-hooks.Rmd
+++ b/vignettes/available-hooks.Rmd
@@ -103,7 +103,7 @@ id: spell-check
 args: [--ignore_files=<ignored_files>, --lang=<language>]
 ```
 
-This hook does not modify files. It will add all words not found in the
+This hook modifies files. It will add all words not found in the
 dictionary to `inst/WORDLIST`, assuming they were spelled correctly but were not
 in the dictionary. An example might be "RStudio". The hook error message will
 contain all words written to `inst/WORDLIST`, so if there were really some
@@ -171,4 +171,3 @@ i.e. remind you to run `codemetar::write_codemeta()` in order to keep
 `codemeta.json` in sync with `DESCRIPTION`.
 
 This hook does not modify any file.
-


### PR DESCRIPTION
Closes #146. Offers isolation from other envs. The key was to use `conda run -n r-precommit /path/to/exec` instead of `/path/to/exec` whenever we need the executable if the installation method was conda (which can be checked from the pre-commit executable path).