### PR TITLE
Add macOS CI again for conda

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -26,7 +26,7 @@ jobs:
         config:
           # macOS
           - {os: macOS-latest,   r: 'release', installation_method: 'brew'}
-#           - {os: macOS-latest,   r: 'release', installation_method: 'conda'}
+           - {os: macOS-latest,   r: 'release', installation_method: 'conda'}
           - {os: macOS-latest,   r: 'release', installation_method: 'pip'}
           # Windows
           - {os: windows-latest, r: 'release', installation_method: 'pip'}
@@ -96,11 +96,11 @@ jobs:
           }
         shell: Rscript {0}
       - name: Install system dependencies (conda)
-        if: matrix.config.installation_method == 'conda'
+        if: matrix.config.installation_method == 'conda' 
         run: |
           reticulate::install_miniconda()
         shell: Rscript {0}
-      - if: runner.os == 'macOS'
+      - if: matrix.config.installation_method == 'conda' && runner.os == 'macOS'
         run: echo "options(reticulate.conda_binary = reticulate:::miniconda_conda())" >> .Rprofile
       - name: Session info
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -100,6 +100,8 @@ jobs:
         run: |
           reticulate::install_miniconda()
         shell: Rscript {0}
+      - if: runner.os == 'macOS'
+         run: echo "options(reticulate.conda_binary = reticulate:::miniconda_conda())" >> .Rprofile
       - name: Session info
         run: |
           options(width = 100)

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -26,7 +26,7 @@ jobs:
         config:
           # macOS
           - {os: macOS-latest,   r: 'release', installation_method: 'brew'}
-           - {os: macOS-latest,   r: 'release', installation_method: 'conda'}
+          - {os: macOS-latest,   r: 'release', installation_method: 'conda'}
           - {os: macOS-latest,   r: 'release', installation_method: 'pip'}
           # Windows
           - {os: windows-latest, r: 'release', installation_method: 'pip'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -100,8 +100,6 @@ jobs:
         run: |
           reticulate::install_miniconda()
         shell: Rscript {0}
-      - if: matrix.config.installation_method == 'conda' && runner.os == 'macOS'
-        run: echo "options(reticulate.conda_binary = reticulate:::miniconda_conda())" >> .Rprofile
       - name: Session info
         run: |
           options(width = 100)

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -101,7 +101,7 @@ jobs:
           reticulate::install_miniconda()
         shell: Rscript {0}
       - if: runner.os == 'macOS'
-         run: echo "options(reticulate.conda_binary = reticulate:::miniconda_conda())" >> .Rprofile
+        run: echo "options(reticulate.conda_binary = reticulate:::miniconda_conda())" >> .Rprofile
       - name: Session info
         run: |
           options(width = 100)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,8 +35,7 @@ Suggests:
     roxygen2,
     spelling,
     styler (>= 1.2),
-    testthat (>= 2.1.0),
-    versions
+    testthat (>= 2.1.0)
 VignetteBuilder: 
     knitr
 Remotes: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests:
     glue,
     knitr,
     lintr,
-    reticulate (>= 1.14),
+    reticulate (>= 1.16),
     rmarkdown,
     roxygen2,
     spelling,
@@ -39,6 +39,8 @@ Suggests:
     versions
 VignetteBuilder: 
     knitr
+Remotes: 
+    rstudio/reticulate@648ca7282b994114e768e0d3ed66e9e5875f9f6f
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, roclets = c( "rd", "namespace",
     "collate", if (rlang::is_installed("pkgapi")) "pkgapi::api_roclet"

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -109,6 +109,7 @@ rprojroot
 rR
 Rr
 Rscript
+rstudio
 RStudio
 rstudioapi
 saveCache

--- a/tests/testthat/test-assumptions.R
+++ b/tests/testthat/test-assumptions.R
@@ -1,7 +1,13 @@
 test_that("documentation regarding desc is still accurate", {
   skip_on_cran()
-  versions <- versions::available.versions("desc")
-  if (max(as.package_version(versions$desc$version)) > "1.2") {
+  if (packageVersion('desc') >= 1.3) {
     rlang::abort("newer version of desc on CRAN. Adapt the warning and maybe add minimal version requirement?")
+  }
+})
+
+test_that("reticulate dev version still required to make tests pass on conda macOS because of https://github.com/rstudio/reticulate/issues/820", {
+  skip_on_cran()
+  if (packageVersion('reticulate') >= 1.18) {
+    rlang::abort("You can depend on the latest CRAN release of reticulate instead of the dev version and remove this assumption test.")
   }
 })

--- a/tests/testthat/test-assumptions.R
+++ b/tests/testthat/test-assumptions.R
@@ -7,6 +7,7 @@ test_that("documentation regarding desc is still accurate", {
 
 test_that("reticulate dev version still required to make tests pass on conda macOS because of https://github.com/rstudio/reticulate/issues/820", {
   skip_on_cran()
+  skip_if_not_installed('reticulate')
   if (packageVersion('reticulate') >= 1.18) {
     rlang::abort("You can depend on the latest CRAN release of reticulate instead of the dev version and remove this assumption test.")
   }


### PR DESCRIPTION
Prefer conda binary from miniconda over system as suggested in https://github.com/rstudio/reticulate/issues/793.