### PR TITLE
Fix .Rbuildignore writing with usethis 2.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     rlang,
     rprojroot,
     rstudioapi,
-    usethis (>= 1.6.0),
+    usethis (>= 2.0.0),
     withr,
     yaml
 Suggests: 

--- a/R/config.R
+++ b/R/config.R
@@ -56,9 +56,7 @@ use_precommit_config <- function(config_source = getOption("precommit.config_sou
   }
 
   if (is_package(root)) {
-    usethis::with_project(root, {
-      usethis::write_union(fs::path(root, ".Rbuildignore"), escaped_name_target)
-    })
+    usethis::write_union(fs::path(root, ".Rbuildignore"), escaped_name_target)
   }
   usethis::ui_todo(c(
     "Edit .precommit-hooks.yaml to (de)activate the hooks you want to use. ",

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -41,9 +41,26 @@ test_that("defaults to right config depending on whether or not root is a pkg", 
   )
 })
 
-test_that(".Rbuildignore is written to the right directory", {
+test_that(".Rbuildignore is written to the right directory when root is relative", {
   root <- tempfile()
   fs::dir_create(root)
+
+  withr::with_dir(root, {
+    desc <- desc::description$new("!new")
+    desc$set(Package = "test.pkg")
+    desc$write("DESCRIPTION")
+  })
+  withr::with_dir(
+    fs::path_dir(root),
+    use_precommit_config(root = fs::path_file(root))
+  )
+  expect_true(fs::file_exists(fs::path(root, ".Rbuildignore")))
+})
+
+test_that(".Rbuildignore is written to the right directory when root is absolute", {
+  root <- tempfile()
+  fs::dir_create(root)
+
   withr::with_dir(root, {
     desc <- desc::description$new("!new")
     desc$set(Package = "test.pkg")

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -40,3 +40,15 @@ test_that("defaults to right config depending on whether or not root is a pkg", 
     "proj\\.yaml"
   )
 })
+
+test_that(".Rbuildignore is written to the right directory", {
+  root <- tempfile()
+  fs::dir_create(root)
+  withr::with_dir(root, {
+    desc <- desc::description$new("!new")
+    desc$set(Package = "test.pkg")
+    desc$write("DESCRIPTION")
+  })
+  use_precommit_config(root = root)
+  expect_true(fs::file_exists(fs::path(root, ".Rbuildignore")))
+})


### PR DESCRIPTION
Seems like missing unit tests for #189 got us. `{usethis}` 2.0.0 contains a fix to our workaround for https://github.com/r-lib/usethis/issues/1125, so the workaround fails (at least locally for me, let's see what GitHub Actions say). A unit test would have caused their rev-dep checks to fail and let us fix the problem in advance. I think I should really put some effort into easily maintainable testing infra. -.- 

cc: @krzyslom 