### PR TITLE
Test legacy hook scripts

### DIFF
--- a/.github/workflows/hook-tests-legacy.yml
+++ b/.github/workflows/hook-tests-legacy.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           git fetch origin refs/tags/v0.1.3:refs/tags/v0.1.3
           git checkout v0.1.3 -- inst/bin
+          git checkout v0.1.3 -- tests/testthat/test-all.R  
       - name: Query dependencies
         run: |
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")

--- a/.github/workflows/hook-tests-legacy.yml
+++ b/.github/workflows/hook-tests-legacy.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           devtools::load_all()
           testthat::test_file(
-            "tests/testthat/test-hooks.R",
+            "tests/testthat/test-all.R",
             reporter = testthat::MultiReporter$new(list(
               testthat::CheckReporter$new(), testthat::FailReporter$new()
             ))

--- a/.github/workflows/hook-tests-legacy.yml
+++ b/.github/workflows/hook-tests-legacy.yml
@@ -78,8 +78,8 @@ jobs:
             install.packages("renv", repos = c(CRAN = "https://cloud.r-project.org"))
           }
           renv::install(c('testthat', 'devtools'))
-          # some testing infrastructure we need is in R/testing.R
-          renv::install(getwd(), dependencies = TRUE) 
+          renv::settings$package.dependency.fields(c("Imports", "Depends", "LinkingTo", "Suggests"))
+          renv::install(getwd()) 
         shell: Rscript {0}
       - name: Session info (testing environment)
         run: |

--- a/.github/workflows/hook-tests-legacy.yml
+++ b/.github/workflows/hook-tests-legacy.yml
@@ -6,8 +6,7 @@ on:
     branches:
       - master
 
-name: Hook tests
-
+name: Legacy hook tests
 jobs:
   hook-test:
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/hook-tests-legacy.yml
+++ b/.github/workflows/hook-tests-legacy.yml
@@ -1,0 +1,118 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: Hook tests
+
+jobs:
+  hook-test:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-18.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
+    env:
+      RSPM: ${{ matrix.config.rspm }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+      - name: checkout old hook scripts
+        run: |
+          git fetch origin refs/tags/v0.1.3:refs/tags/v0.1.3
+          git checkout v0.1.3 -- inst/bin
+      - name: Query dependencies
+        run: |
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+      - name: Cache R packages (macOs)
+        if: startsWith(runner.os, 'macOS')
+        uses: actions/cache@v2
+        with:
+          path: ~/Library/Application Support/renv
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('renv.lock') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      - name: Cache R packages (Linux)
+        if: startsWith(runner.os, 'Linux')
+        uses: actions/cache@v2
+        with:
+          path: ~/.local/share/renv
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('renv.lock') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      - name: Cache R packages (Windows)
+        if: startsWith(runner.os, 'Windows')
+        uses: actions/cache@v2
+        with:
+          path: ~\AppData\Local\renv
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('renv.lock') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          Rscript -e "install.packages('remotes', repos = Sys.getenv('RSPM'))"
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "18.04"), sep = "\n")')
+      - name: Perpare testing environment
+        run: |
+          # testing dependencies (incl. {precommit}) live in global R library, 
+          # hook dependencies in renv, which is only activated when child R
+          # process is invoked, e.g. as in run_test()
+          if (!requireNamespace("renv", quietly = TRUE)) {
+            install.packages("renv", repos = c(CRAN = "https://cloud.r-project.org"))
+          }
+          renv::install(c('testthat', 'devtools'))
+          # some testing infrastructure we need is in R/testing.R
+          renv::install(getwd(), dependencies = TRUE) 
+        shell: Rscript {0}
+      - name: Session info (testing environment)
+        run: |
+          renv::install('sessioninfo', repos = 'cloud.r-project.org')
+          options(width = 100)
+          pkgs <- installed.packages()[, "Package"]
+          sessioninfo::session_info(pkgs, include_base = TRUE)
+        shell: Rscript {0}
+      - name: Test
+        run: |
+          devtools::load_all()
+          testthat::test_file(
+            "tests/testthat/test-hooks.R",
+            reporter = testthat::MultiReporter$new(list(
+              testthat::CheckReporter$new(), testthat::FailReporter$new()
+            ))
+          )
+        shell: Rscript {0}
+      - name: Show testthat output
+        if: always()
+        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+      - name: Assert no leakage from testing to hook env (1/2)
+        run: |
+          Rscript -e "renv::install('usethis'); path_pkg <- file.path(tempdir(), 'someP'); usethis::create_package(path_pkg); renv::install(path_pkg)"
+      - name: Assert no leakage from testing to hook env (2/2)
+        env: 
+            R_PRECOMMIT_HOOK_ENV: "1"
+        run: |
+          Rscript -e "if ('someP' %in% rownames(installed.packages())) stop('environment isolation not working: You installed a package into the testing environment and it is available in the hook environment')"
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          path: check

--- a/.github/workflows/hook-tests-legacy.yml
+++ b/.github/workflows/hook-tests-legacy.yml
@@ -77,8 +77,8 @@ jobs:
           if (!requireNamespace("renv", quietly = TRUE)) {
             install.packages("renv", repos = c(CRAN = "https://cloud.r-project.org"))
           }
-          renv::install(c('testthat', 'devtools'))
-          renv::settings$package.dependency.fields(c("Imports", "Depends", "LinkingTo", "Suggests"))
+          renv::install(c('testthat', 'devtools', 'desc'))
+          renv::install(desc::desc_get_deps()$package) # install all deps
           renv::install(getwd()) 
         shell: Rscript {0}
       - name: Session info (testing environment)

--- a/.github/workflows/hook-tests-legacy.yml
+++ b/.github/workflows/hook-tests-legacy.yml
@@ -102,14 +102,6 @@ jobs:
         if: always()
         run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
-      - name: Assert no leakage from testing to hook env (1/2)
-        run: |
-          Rscript -e "renv::install('usethis'); path_pkg <- file.path(tempdir(), 'someP'); usethis::create_package(path_pkg); renv::install(path_pkg)"
-      - name: Assert no leakage from testing to hook env (2/2)
-        env: 
-            R_PRECOMMIT_HOOK_ENV: "1"
-        run: |
-          Rscript -e "if ('someP' %in% rownames(installed.packages())) stop('environment isolation not working: You installed a package into the testing environment and it is available in the hook environment')"
       - name: Upload check results
         if: failure()
         uses: actions/upload-artifact@main

--- a/.github/workflows/hook-tests.yaml
+++ b/.github/workflows/hook-tests.yaml
@@ -87,7 +87,7 @@ jobs:
           }
           renv::install(c('testthat', 'devtools'))
           # some testing infrastructure we need is in R/testing.R
-          renv::install(getwd(), dependencies = TRUE) 
+          renv::install(getwd())
         shell: Rscript {0}
       - name: Session info (testing environment)
         run: |

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@
   `language: script` from the [pre-commit framework](https://pre-commit.com). 
   This requires `pre-commit >= 2.11.1`. All hooks and dependencies are now 
   contained in a virtual environment with [`{renv}`](https://rstudio.github.io/renv/)
-  (#233, #250, #260). Thanks to {renv}'s excellent 
+  (#233, #250, #260, #264). Thanks to {renv}'s excellent 
   [caching](https://rstudio.github.io/renv/articles/renv.html#cache-1), this 
   does not consume much space and is fast. This makes output
   of hooks more consistent across different local setups, make manual dependency

--- a/renv.lock
+++ b/renv.lock
@@ -4,7 +4,7 @@
     "Repositories": [
       {
         "Name": "CRAN",
-        "URL": "https://packagemanager.rstudio.com/all/latest"
+        "URL": "https://cran.rstudio.com"
       }
     ]
   },

--- a/vignettes/testing.Rmd
+++ b/vignettes/testing.Rmd
@@ -18,7 +18,7 @@ pre-commit >= 2.11.0 supports R as a language and each hook repo has its own
 virtual environment with package versions locked. For that reason, we should
 also test with exactly these versions.
 
-This package has three testing worfklows:
+This package has four testing workflows:
 
 * hook testing. Tests the hooks (as well as hook script helpers?) in the renv in
   which they'll be shipped. No R CMD Check or pre-commit executable needed.
@@ -30,9 +30,21 @@ This package has three testing worfklows:
   from `run_test()`, the only way to do this is to set an env variable when
   running `run_test()` and check in the user R profile if it is set, and then
   activate the renv. This is done with `R_PRECOMMIT_HOOK_ENV`.
+
+* Legacy hook testing: It is possible that someone updates the R package 
+  {precommit}, but not the hook revision (e.g. with `precommit::autoupdate()`) 
+  or vice versa. If the hook revision is updated to `>= 0.2.0`, all hook scripts
+  and {precommit} functions called from the hook script are from the same 
+  version of {precommit}, so we don't need to test hook compatibility. If the R
+  package is updated but not the hook revision, old hook scripts are called with 
+  while the {precommit} functions in them are from a new package version. Hence, 
+  we need compatibility between new packages and old hook scripts, which is 
+  exactly what is tested with this workflow. Until there are breaking changes in
+  the *hook script helpers* family of exported functions, there should not be 
+  a problem.
   
 * complete testing: Tests hooks as well as usethis like access functionality 
-  with latest CRAN packges, on all platforms, with all installation methods.
+  with latest CRAN packages, on all platforms, with all installation methods.
 
 * CRAN testing. On CRAN, complete testing is ran, tests that check pre-commit
   executable access are disabled.


### PR DESCRIPTION
Closes #263. This test for `v0.1.3` hook scripts and associated tests. We'll have to see if we ever want to require up-to-date hook revision for up-to-date {precommit}.