### PR TITLE
Ignore non-R chunks in robust purling

### DIFF
--- a/R/purl.R
+++ b/R/purl.R
@@ -18,7 +18,7 @@ robust_purl <- function(path) {
 
   if (tolower(ext) == "rmd") {
     lines[!should_not_override] <- gsub(
-      "^```\\{.*\\}.*", "```{r purl = TRUE}", lines[!should_not_override]
+      "^```\\{ *[Rr] *.*\\}.*", "```{r purl = TRUE}", lines[!should_not_override]
     )
   } else if (tolower(ext) == "rnw") {
     lines[!should_not_override] <- gsub(

--- a/tests/testthat/in/parsable-R-success.Rmd
+++ b/tests/testthat/in/parsable-R-success.Rmd
@@ -15,3 +15,20 @@ parsable + code
 ```{r, purl=FALSE}
  fas / fk 12 -
 ```
+
+
+```{nonR chunk}
+this is 
+```
+
+```{f , x= 2}
+this is 
+```
+
+```{f, x= 2}
+this is 
+```
+
+```{ f, x= 2}
+this is 
+```


### PR DESCRIPTION
Closes #381. See also for both parsable R and deps in desc hook:
https://github.com/r-lib/styler/runs/5419721151?check_suite_focus=true