### PR TITLE
update regex patterns for forbid_to_commit; fixes #409

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,7 +142,7 @@ repos:
         name: Don't commit common R artifacts
         entry: Cannot commit .Rhistory, .Rdata, .csv and similar.
         language: fail
-        files: '\.Rhistory|\.csv|\.RData|\.Rds|\.rds$'
+        files: '\.(Rhistory|csv|RData|Rds|rds)$'
         # `exclude: <regex>` to allow committing specific files.
     -   id: spell-check-ordered-exclude
         name: Ordered regex pattern for spell-check exclusion

--- a/inst/pre-commit-config-pkg.yaml
+++ b/inst/pre-commit-config-pkg.yaml
@@ -66,7 +66,7 @@ repos:
         name: Don't commit common R artifacts
         entry: Cannot commit .Rhistory, .RData, .Rds or .rds.
         language: fail
-        files: '\.Rhistory|\.RData|\.Rds|\.rds$'
+        files: '\.(Rhistory|RData|Rds|rds)$'
         # `exclude: <regex>` to allow committing specific files
 
 ci:

--- a/inst/pre-commit-config-proj.yaml
+++ b/inst/pre-commit-config-proj.yaml
@@ -59,7 +59,7 @@ repos:
         name: Don't commit common R artifacts
         entry: Cannot commit .Rhistory, .RData, .Rds or .rds.
         language: fail
-        files: '\.Rhistory|\.RData|\.Rds|\.rds$'
+        files: '\.(Rhistory|RData|Rds|rds)$'
         # `exclude: <regex>` to allow committing specific files
 
 ci:

--- a/tests/testthat/reference-objects/pre-commit-config.yaml
+++ b/tests/testthat/reference-objects/pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
         name: Don't commit common R artifacts
         entry: Cannot commit .Rhistory, .Rdata, .csv and similar.
         language: fail
-        files: '\.Rhistory|\.csv|\.RData|\.Rds|\.rds$'
+        files: '\.(Rhistory|csv|RData|Rds|rds)$'
         # `exclude: <regex>` to allow committing specific files.
     -   id: spell-check-ordered-exclude
         name: Ordered regex pattern for spell-check exclusion


### PR DESCRIPTION
Before you merge, maybe check out whether there is/was a reason for these lines:
https://github.com/lorenzwalthert/precommit/blob/fcecc1049dbbcdbf2a6662ba295760323f804536/inst/pre-commit-hooks.yaml#L106
they could be written
``` yaml
files: '\.(...)$'
```
:question: There are a few like that in other places too. Whatever the reason, the changes here worked for me on [this commit](https://github.com/ropenscilabs/deposits/commit/957410a442b6dbf8249ae6af5e9d8a8301974b9d) which accepted a bunch of `data.Rds.R`-type filenames:rocket: