### PR TITLE
don't presume pre-commit-config exists in ensure_renv_compat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ editor_options:
 
 # precommit v0.3.0.9000
 
+-   Fix bug that prevented pkg load outside directories with precommit files
+    (#413).
 -   hook `forbid-to-commit` in template `.pre-commit-config.yaml` has
     now the correct `exclude-files` regular expression to ignore 
     `.csv`, `.RData`, `.Rds`, `.rds` and `.Rhistory` (#410).

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ editor_options:
 # precommit v0.3.0.9000
 
 -   Fix bug that prevented pkg load outside directories with precommit files
-    (#413).
+    (@mpadge, #413).
 -   hook `forbid-to-commit` in template `.pre-commit-config.yaml` has
     now the correct `exclude-files` regular expression to ignore 
     `.csv`, `.RData`, `.Rds`, `.rds` and `.Rhistory` (#410).

--- a/R/setup.R
+++ b/R/setup.R
@@ -179,6 +179,9 @@ ensure_renv_precommit_compat <- function(package_version_renv = utils::packageVe
   } else {
     withr::local_dir(root)
     path_config <- ".pre-commit-config.yaml"
+    if (!file_exists(path_config)) {
+        return()
+    }
     config_lines <- readLines(path_config, encoding = "UTF-8")
     has_renv <- fs::file_exists("renv.lock")
     if (!has_renv) {


### PR DESCRIPTION
@lorenzwalthert Easy to reproduce the :bug: behind this one:

1. Go to a directory anywhere that is not an R package and/or does not have a `pre-commit-config.yaml` file
2. Start R
3. type `library(precommit)` and watch it error

----

Another question for you here, before i open a hopefully unnecessary issue: I have entirely broken `precommit` (this package, not the python one) by manually removing all cached `renv` directories, and removing `~/.cache/R/R.cache`. precommit now fails to find any renv-ed versions of `desc`, `styler`, `docopt`, whatever. I've tried removing and reinstalling everything, but no matter what I do precommit fails to reestablish its renv. Any quick tips? Or shall i open an issue?