### PR TITLE
Enable skipping linters

### DIFF
--- a/inst/hooks/exported/lintr.R
+++ b/inst/hooks/exported/lintr.R
@@ -3,11 +3,13 @@
 
 "Run lintr on R files during a precommit.
 Usage:
-  lintr [--warn_only] <files>...
+  lintr [--warn_only] [--exclude_lintr=<linter1,linter2>] <files>...
 Options:
   --warn_only  Print lint warnings instead of blocking the commit. Should be
                used with `verbose: True` in `.pre-commit-config.yaml`.
                Otherwise, lints will never be shown to the user.
+  --exclude_lintr linters to exclude. Should be a comma-separated entry, e.g.
+                  --exclude_lintr=object_name_linter,object_usage_linter
 " -> doc
 
 arguments <- docopt::docopt(doc)
@@ -23,8 +25,13 @@ if (any(lintr_staged)) {
   )
 }
 
+exclude_linters <- trimws(strsplit(arguments$exclude_lintr, ",")[[1]])
+n_exclude <- length(exclude_linters)
+exclude_linters <- setNames(rep(list(NULL), n_exclude), exclude_linters)
+default_linters <- do.call(lintr::linters_with_defaults, exclude_linters)
+
 for (path in arguments$files) {
-  lints <- lintr::lint(path)
+  lints <- lintr::lint(path, linters = default_linters)
   if (length(lints) > 0) {
     cat("File `", path, "` is not lint free\n", sep = "")
     rendered_lints <- capture.output(print(lints))


### PR DESCRIPTION
My specific use-case is that I want to use some variable names with dots (vs snake_case) and `lintr` doesn't like them, but I also want the other linters to run.

This PR adds a new `--exclude_lintr` argument that accepts a comma-separated list of linters to exclude, then runs the linter with these set to `NULL`.

I'm having trouble testing this - even though I've set my `.pre-commit-config.yaml` to 
```
repos:
-   repo: https://github.com/jonocarroll/precommit
    rev: v0.3.1
    hooks: 
    -   id: lintr
        args: [--exclude_lintr=object_name_linter]
```
I still see the usage message for the original (which doesn't have this new argument). Is there something I'm missing to use an alternative config?