### PR TITLE
Add root to remaining hooks. Issues with roxygenize tests

### DIFF
--- a/inst/hooks/exported/codemeta-description-updated.R
+++ b/inst/hooks/exported/codemeta-description-updated.R
@@ -1,5 +1,21 @@
 #!/usr/bin/env Rscript
 
+"A hook to make sure DESCRIPTION hasn’t been edited more recently than 
+codemeta.json.
+
+Usage:
+  codemeta-description-updated [--root=<root_>] <_ignored>...
+
+Options:
+  --root=<root_>  Path relative to the git root that contains the R package 
+                  root [default: .].
+
+" -> doc
+
+
+arguments <- docopt::docopt(doc)
+setwd(arguments$root)
+
 # adapted from https://github.com/lorenzwalthert/precommit/blob/f4413cfe6282c84f7176160d06e1560860c8bd3d/inst/hooks/exported/readme-rmd-rendered
 if (!file.exists("DESCRIPTION")) {
   rlang::abort("No `DESCRIPTION` found in repository.")

--- a/inst/hooks/exported/roxygenize.R
+++ b/inst/hooks/exported/roxygenize.R
@@ -14,13 +14,17 @@ This check should run *after* check that modify the files that are passed to
 them (like styler) because they will never modify their input .R files.
 
 Usage:
-  roxygenize [--no-warn-cache] <files>...
+  roxygenize [--no-warn-cache] [--root=<root_>] <files>...
 
 Options:
   --no-warn-cache  Suppress the warning about a missing permanent cache.
+  --root=<root_>  Path relative to the git root that contains the R package root [default: .].
 
 " -> doc
 arguments <- docopt::docopt(doc)
+arguments$files <- normalizePath(arguments$files) # because working directory changes to root
+setwd(arguments$root)
+
 if (packageVersion("precommit") < "0.1.3.9010") {
   rlang::abort(paste(
     "This hooks only works with the R package {precommit} >= 0.1.3.9010",

--- a/inst/hooks/exported/use-tidy-description.R
+++ b/inst/hooks/exported/use-tidy-description.R
@@ -1,4 +1,24 @@
 #!/usr/bin/env Rscript
+
+"A hook to run usethis::use_tidy_description() to ensure dependencies are 
+ordered alphabetically and fields are in standard order.
+
+Usage:
+  use-tidy-description [--root=<root_>] <_ignored>...
+
+Options:
+  --root=<root_>  Path relative to the git root that contains the R package root [default: .].
+
+" -> doc
+
+
+arguments <- docopt::docopt(doc)
+setwd(arguments$root)
+
+if (!file.exists("DESCRIPTION")) {
+  rlang::abort("No `DESCRIPTION` found in repository.")
+}
+
 description <- desc::description$new()
 description_old <- description$clone(deep = TRUE)
 deps <- description$get_deps()


### PR DESCRIPTION
See: https://github.com/lorenzwalthert/precommit/pull/432

I seem to get a `docopt` issue when specifying an option without any arguments. See: https://github.com/lorenzwalthert/precommit/issues/429#issuecomment-1179806044. Therefore, I added `<_ignored>...` arguments as a workaround. I bet there is a better solution, but I wanted to get this initial commit out quickly.