### PR TITLE
Updated spelling of required

### DIFF
--- a/inst/pre-commit-config-pkg.yaml
+++ b/inst/pre-commit-config-pkg.yaml
@@ -58,7 +58,7 @@ repos:
 -   repo: https://github.com/pre-commit-ci/pre-commit-ci-config
     rev: v1.5.1
     hooks:
-    # Only reuiqred when https://pre-commit.ci is used for config validation
+    # Only required when https://pre-commit.ci is used for config validation
     -   id: check-pre-commit-ci-config
 -   repo: local
     hooks:

--- a/inst/pre-commit-config-proj.yaml
+++ b/inst/pre-commit-config-proj.yaml
@@ -51,7 +51,7 @@ repos:
 -   repo: https://github.com/pre-commit-ci/pre-commit-ci-config
     rev: v1.5.1
     hooks:
-    # Only reuiqred when https://pre-commit.ci is used for config validation
+    # Only required when https://pre-commit.ci is used for config validation
     -   id: check-pre-commit-ci-config
 -   repo: local
     hooks:


### PR DESCRIPTION
Hi, 

Feel free to remove this pull request, but I just installed the `R` package and saw that the spelling of `required` was incorrect in two of the example yaml configurations.  So this PR just fixes the spelling  in those cases. 