### PR TITLE
Check if YAML files are valid

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,6 +90,7 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks: 
+    -   id: check-yaml
     -   id: check-added-large-files
     -   id: end-of-file-fixer
         exclude: '\.Rd' # sometimes roxygen fails to generate EOF blank line.


### PR DESCRIPTION
YAML formatter in VS code fails for precommit config file locally, so just wanted to see if this can be reproduced using precommit itself.