### PR TITLE
Fix roxygenise cache invalidation

### DIFF
--- a/inst/hooks/exported/roxygenize.R
+++ b/inst/hooks/exported/roxygenize.R
@@ -42,7 +42,7 @@ rd_files_before_roxygen <- list.files("man", pattern = "\\.Rd$")
 
 if (!is.null(cache)) {
   candidates <- intersect(
-    list.files(c("R", "man"), full.names = TRUE),
+    normalizePath(list.files(c("R", "man"), full.names = TRUE)),
     arguments$files
   )
   all_files <- file.info(candidates)


### PR DESCRIPTION
roxygenise is never triggered anymore. A regression introduced with exposed root arguments for hooks.