### PR TITLE
✏️Correct typo of required in comment in .pre-commit-config.yml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,7 +98,7 @@ repos:
 -   repo: https://github.com/pre-commit-ci/pre-commit-ci-config
     rev: v1.5.1
     hooks:
-    # Only reuiqred when https://pre-commit.ci is used for config validation
+    # Only required when https://pre-commit.ci is used for config validation
     -   id: check-pre-commit-ci-config
 -   repo: https://github.com/lorenzwalthert/gitignore-tidy
     rev: 475bf5d96927a1887ce2863ff3075b1d7240bc51


### PR DESCRIPTION
See also #453 which corrected this typo in the files in the inst folder.

I noticed this typo in my config file after using `precommit::use_precommit()` to setup pre-commit for my R package, and then found out that this was mostly likely fixed by #453 but didn't make it to a new release yet (still using 0.3.2, and changes on main since then [here](https://github.com/lorenzwalthert/precommit/compare/v0.3.2...main indicate it was fixed since then) ). However, when searching for the string in question I found another instance of it in the precommit config file used by the project itself. I thought you might want to correct that as well, hence this PR. ^^ 

Additional note, when saving the file my editor removed a lot of trailing spaces automatically. I did not add that to this commit, but maybe something to look into it, since it's a common setting nowadays. 

<details>
<summary>Version details</summary>

> R version 4.2.2 (2022-10-31 ucrt)
> Platform: x86_64-w64-mingw32/x64 (64-bit)

> precommit::version_precommit()
[1] "2.20.0"
> packageVersion("precommit")
[1] ‘0.3.2’

</details>
