### PR TITLE
correct typo from dash to underscore

### DIFF
--- a/vignettes/available-hooks.Rmd
+++ b/vignettes/available-hooks.Rmd
@@ -52,7 +52,7 @@ repos:
     rev: {rev}
     hooks:
     -   id: lintr
-        args: [--warn-only, --key=value]
+        args: [--warn_only, --key=value]
 "))
 ```
 


### PR DESCRIPTION
Corrects warning argument by changing dash to underscore