### PR TITLE
installation method for dev dependencies is not pre-commit specific

### DIFF
--- a/.github/workflows/hook-tests.yaml
+++ b/.github/workflows/hook-tests.yaml
@@ -68,7 +68,7 @@ jobs:
         run: |
           source('renv/activate.R')
           renv::restore()
-          options(install.packages.compile.from.source = "never", pkgType = "binary")
+          options(pkgType = "binary")
           # install hook-specific additional_dependencies from .pre-commit-config.yaml
           renv::install(c('pkgdown', 'mockery'))
           renv::install(getwd(), dependencies = FALSE) 


### PR DESCRIPTION
Hope to allow installation of {pkgdown} from sources if binary not found for a hook test. In end to end test, this already worked.