### PR TITLE
fix macOS

### DIFF
--- a/.github/workflows/hook-tests.yaml
+++ b/.github/workflows/hook-tests.yaml
@@ -58,8 +58,8 @@ jobs:
       - name: Prepare hook environment
         run: |
           source('renv/activate.R')
-          renv::restore()
           options(install.packages.compile.from.source = "never", pkgType = "binary")
+          renv::restore()
           # install hook-specific additional_dependencies from .pre-commit-config.yaml
           renv::install(c('pkgdown', 'mockery'))
           renv::install(getwd(), dependencies = FALSE) 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -10,6 +10,7 @@ Averick
 bd
 beaefa
 behaviour
+bioconductor
 bliblablupp
 cfe
 ci
@@ -92,6 +93,7 @@ Liberapay
 liberapay
 licensors
 Lifecycle
+LinkingTo
 lintr
 loadCache
 lorenz
@@ -215,6 +217,7 @@ Upvote
 UseR
 usethis
 usr
+vcs
 VignetteBuilder
 Walthert
 walthert


### PR DESCRIPTION
Set options to force binary before `restore`. Potentially adding another repository to `renv.lock` in [f3498c4](https://github.com/lorenzwalthert/precommit/commit/f3498c421d68a1db26de1a1fe3ecc91dd6f03b5e) helps. Conda installation problem still persists and roxygen2 test still fails, but not in installation, but in test phase.