### PR TITLE
Allow filename spaces

### DIFF
--- a/R/testing.R
+++ b/R/testing.R
@@ -181,7 +181,7 @@ hook_state_create <- function(tempdir,
   withr::local_dir(tempdir)
   files <- fs::path_rel(path_candidate_temp, tempdir)
   if(any(grepl(' ', files))){
-    # this filename has spaces. To get system2 to interpolate it correctly (
+    # this filename has spaces. To get system2 to interpolate it correctly
     # (and how it will be provided in real contexts), it needs to be quoted.
     files <- paste0('"', files, '"')
   }

--- a/R/testing.R
+++ b/R/testing.R
@@ -51,9 +51,7 @@ run_test <- function(hook_name,
                      file_transformer = function(files) files,
                      env = character(),
                      expect_success = is.null(std_err),
-                     substitute_spaces = NULL
-                     ) {
-
+                     substitute_spaces = NULL) {
   withr::local_envvar(list(R_PRECOMMIT_HOOK_ENV = "1"))
   path_executable <- fs::dir_ls(system.file(
     fs::path("hooks", "exported"),
@@ -64,9 +62,9 @@ run_test <- function(hook_name,
   }
   path_candidate <- paste0(testthat::test_path("in", file_name), suffix) %>%
     ensure_named(names(file_name), fs::path_file)
-  if(is.null(substitute_spaces)){
+  if (is.null(substitute_spaces)) {
     # set default value based on if there are any hyphens in teh filename
-    substitute_spaces <- any(grepl('-', basename(path_candidate)))
+    substitute_spaces <- any(grepl("-", basename(path_candidate)))
   }
 
   run_test_impl(
@@ -79,7 +77,7 @@ run_test <- function(hook_name,
     env = env,
     expect_success = expect_success
   )
-  if(substitute_spaces){
+  if (substitute_spaces) {
     run_test_impl(
       path_executable, path_candidate,
       std_err = std_err,
@@ -131,7 +129,7 @@ run_test_impl <- function(path_executable,
   copy_artifacts(artifacts, tempdir)
   # if name set use this, otherwise put in root
   path_candidate_temp <- fs::path(tempdir, names(path_candidate))
-  if(substitute_spaces){
+  if (substitute_spaces) {
     path_candidate_temp <- gsub("-", " ", path_candidate_temp)
   }
   fs::dir_create(fs::path_dir(path_candidate_temp))
@@ -180,7 +178,7 @@ hook_state_create <- function(tempdir,
                               env) {
   withr::local_dir(tempdir)
   files <- fs::path_rel(path_candidate_temp, tempdir)
-  if(any(grepl(' ', files))){
+  if (any(grepl(" ", files))) {
     # this filename has spaces. To get system2 to interpolate it correctly
     # (and how it will be provided in real contexts), it needs to be quoted.
     files <- paste0('"', files, '"')

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -193,6 +193,7 @@ stopifnot
 styler
 sublicenses
 Sublicensing
+substiuted
 Sys
 SystemRequirements
 tcltk

--- a/inst/hooks/exported/style-files.R
+++ b/inst/hooks/exported/style-files.R
@@ -38,7 +38,10 @@ if (length(keys) > 0) {
   doc <- gsub("<files>...", insert, paste0(doc, paste(key_value_pairs, collapse = "\n")))
 }
 
-arguments <- docopt::docopt(doc, args)
+# docopt provides special processing for a single string, and it treats a
+# 1-element vector as a string, which is a problem.
+# So, we force it to process the args as a vector by add a no-opt empty string.
+arguments <- docopt::docopt(doc, c(args, ''))
 if (packageVersion("styler") < "1.3.2") {
   stop(
     "Your styler version is outdated. ",

--- a/inst/hooks/exported/style-files.R
+++ b/inst/hooks/exported/style-files.R
@@ -41,7 +41,7 @@ if (length(keys) > 0) {
 # docopt provides special processing for a single string, and it treats a
 # 1-element vector as a string, which is a problem.
 # So, we force it to process the args as a vector by add a no-opt empty string.
-arguments <- docopt::docopt(doc, c(args, ''))
+arguments <- docopt::docopt(doc, c(args, ""))
 if (packageVersion("styler") < "1.3.2") {
   stop(
     "Your styler version is outdated. ",

--- a/man/run_test.Rd
+++ b/man/run_test.Rd
@@ -14,7 +14,8 @@ run_test(
   artifacts = NULL,
   file_transformer = function(files) files,
   env = character(),
-  expect_success = is.null(std_err)
+  expect_success = is.null(std_err),
+  substitute_spaces = NULL
 )
 }
 \arguments{
@@ -55,6 +56,13 @@ made.}
 \item{expect_success}{Whether or not an exit code 0 is expected. This can
 be derived from \code{std_err}, but sometimes, non-empty stderr does not mean
 error, but just a message.}
+
+\item{substitute_spaces}{If TRUE, the test is run twice, once in the general
+context and once in which the filenames have spaces substiuted for all
+hyphens. This is important because docopt behaves differently if the
+arguments are a length-1 character vector with spaces.
+If no parameter provided, default is TRUE if there are hyphens to
+substitute, FALSE otherwise.}
 }
 \description{
 Tests for the executables used as pre-commit hooks via \code{entrypoint} in

--- a/man/run_test_impl.Rd
+++ b/man/run_test_impl.Rd
@@ -13,7 +13,8 @@ run_test_impl(
   artifacts,
   file_transformer,
   env,
-  expect_success
+  expect_success,
+  substitute_spaces = FALSE
 )
 }
 \arguments{
@@ -40,6 +41,10 @@ temporary location and the value is the source of the file.}
 \item{expect_success}{Whether or not an exit code 0 is expected. This can
 be derived from \code{std_err}, but sometimes, non-empty stderr does not mean
 error, but just a message.}
+
+\item{substitute_spaces}{If TRUE, the temporary file has spaces substiuted for
+any and all hyphens, to ensure that the test runs when there are spaces encoded
+in the filename (In some instances, spaces are a problem for docopt).}
 }
 \description{
 Implement a test run

--- a/man/run_test_impl.Rd
+++ b/man/run_test_impl.Rd
@@ -43,8 +43,8 @@ be derived from \code{std_err}, but sometimes, non-empty stderr does not mean
 error, but just a message.}
 
 \item{substitute_spaces}{If TRUE, the temporary file has spaces substiuted for
-any and all hyphens, to ensure that the test runs when there are spaces encoded
-in the filename (In some instances, spaces are a problem for docopt).}
+any and all hyphens - this is intended to be set by internal calls from
+\code{run_test}.}
 }
 \description{
 Implement a test run

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -211,7 +211,8 @@ run_test(
   "parsable-R",
   suffix = "-fail.Rmd",
   std_out = "parsable-R-fail.Rmd",
-  std_err = "1 1"
+  std_err = "1 1",
+  substitute_spaces = FALSE
 )
 
 ### . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ..
@@ -303,7 +304,8 @@ run_test("deps-in-desc",
   "deps-in-desc",
   suffix = "-fail.Rmd", std_err = "Dependency check failed",
   std_out = "deps-in-desc-fail.Rmd`: ttyzp",
-  artifacts = c("DESCRIPTION" = test_path("in/DESCRIPTION"))
+  artifacts = c("DESCRIPTION" = test_path("in/DESCRIPTION")),
+  substitute_spaces = FALSE
 )
 
 run_test("deps-in-desc",


### PR DESCRIPTION
Updated `style-files.R` to ensure that `docopt` always processes length-1 character vectors in array context. 

The real meat of the PR is updates to the testing framework to ensure that filenames with spaces render the same way filenames without spaces render.