### PR TITLE
House keeping

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,5 +48,5 @@ Roxygen: list(markdown = TRUE, roclets = c( "rd", "namespace", "collate",
     if (rlang::is_installed("pkgapi")) "pkgapi::api_roclet" else {
     warning("Please install r-lib/pkgapi to make sure the file API is kept
     up to date"); NULL} ) )
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 SystemRequirements: git

--- a/R/cache.R
+++ b/R/cache.R
@@ -1,10 +1,10 @@
-#' Issue a warning if `{R.cache}` uses temporary cache only
+#' Issue a warning if \{R.cache\} uses temporary cache only
 #'
 #' This function used to check if a permanent cache was available and issue a
-#' warning if not, but since {R.cache} version `0.15.0` (release date
+#' warning if not, but since \{R.cache\} version `0.15.0` (release date
 #' 2021-04-27), a permanent directory will be used automatically, so this check
 #' if redundant. the function is kept in the package for compatibility, i.e.
-#' if someone updates the R package {precommit} but not the hook revisions.
+#' if someone updates the R package \{precommit\} but not the hook revisions.
 #' @param temp_cache_is_enough ignored.
 #' @family hook script helpers
 #' @keywords internal

--- a/R/release.R
+++ b/R/release.R
@@ -144,7 +144,7 @@ release_prechecks <- function(bump, is_cran) {
   dsc
 }
 
-#' Updates the hook version ref of {precommit} in a `.pre-commit-config` file
+#' Updates the hook version ref of \{precommit\} in a `.pre-commit-config` file
 #'
 #' This is useful in the release process because when releasing a new version,
 #' we must make sure the template that is used with `precommit::use_precommit()`

--- a/man/may_require_permanent_cache.Rd
+++ b/man/may_require_permanent_cache.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/cache.R
 \name{may_require_permanent_cache}
 \alias{may_require_permanent_cache}
-\title{Issue a warning if \code{{R.cache}} uses temporary cache only}
+\title{Issue a warning if \{R.cache\} uses temporary cache only}
 \usage{
 may_require_permanent_cache(temp_cache_is_enough = FALSE)
 }
@@ -11,10 +11,10 @@ may_require_permanent_cache(temp_cache_is_enough = FALSE)
 }
 \description{
 This function used to check if a permanent cache was available and issue a
-warning if not, but since {R.cache} version \verb{0.15.0} (release date
+warning if not, but since \{R.cache\} version \verb{0.15.0} (release date
 2021-04-27), a permanent directory will be used automatically, so this check
 if redundant. the function is kept in the package for compatibility, i.e.
-if someone updates the R package {precommit} but not the hook revisions.
+if someone updates the R package \{precommit\} but not the hook revisions.
 }
 \seealso{
 Other hook script helpers: 

--- a/man/update_rev_in_config.Rd
+++ b/man/update_rev_in_config.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/release.R
 \name{update_rev_in_config}
 \alias{update_rev_in_config}
-\title{Updates the hook version ref of {precommit} in a \code{.pre-commit-config} file}
+\title{Updates the hook version ref of \{precommit\} in a \code{.pre-commit-config} file}
 \usage{
 update_rev_in_config(new_version, path = "inst/pre-commit-config.yaml")
 }

--- a/tests/testthat/test-hook-roxygenize.R
+++ b/tests/testthat/test-hook-roxygenize.R
@@ -154,7 +154,7 @@ test_that("warns if there is any other warning", {
     "R/blur.R"
   )
 
-  expect_warning(
+  expect_message(
     roxygenize_with_cache(list(getwd()), dirs = dirs_R.cache("roxygenize")),
     "(with|a) @name"
   )

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -251,7 +251,7 @@ run_test("deps-in-desc",
 
 # in sub directory with wrong root
 run_test("deps-in-desc",
-  suffix = "-fail.R", std_err = "contains a file",
+  suffix = "-fail.R", std_err = "Could not find R package",
   file_transformer = function(files) {
     fs::path_abs(fs::file_move(files, "rpkg"))
   },


### PR DESCRIPTION
Closes #535. Need to update lock file to contain latest {roxygen2} release, which is not installed currently in hook tests (they fail therefore) and on windows (with {pak} since installs binaries), then, the errors will go away.