### PR TITLE
Release {precommit} 0.4.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
     # Only required when https://pre-commit.ci is used for config validation
     -   id: check-pre-commit-ci-config
 -   repo: https://github.com/lorenzwalthert/gitignore-tidy
-    rev: 475bf5d96927a1887ce2863ff3075b1d7240bc51
+    rev: 0.1.2
     hooks: 
     -   id: tidy-gitignore
 -   repo: local

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: precommit
 Title: Pre-Commit Hooks
-Version: 0.4.0.9000
+Version: 0.4.1
 Author: Lorenz Walthert
 Maintainer: Lorenz Walthert <lorenz.walthert@icloud.com>
 Description: Useful git hooks for R building on top of the multi-language

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# precommit 0.4.1
+
+This release ensures unit tests can handle the error messages from {styler} 
+correctly that were modified slightly. Apart from hook dependency updates, this
+release adds no user-facing changes.
+
 # precommit 0.4.0
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@ This release ensures unit tests can handle the error messages from {styler}
 correctly that were modified slightly. Apart from hook dependency updates, this
 release adds no user-facing changes.
 
+Thanks [&#x0040;joshpersi](https://github.com/joshpersi) for contributing to this 
+release.
+
+
 # precommit 0.4.0
 
 

--- a/R/config.R
+++ b/R/config.R
@@ -84,7 +84,7 @@ set_config_source <- function(config_source,
 
     target <- fs::path_ext_set(tmp, fs::path_ext(config_source))
     utils::download.file(config_source, target, quiet = TRUE)
-    rlang::with_handlers(
+    rlang::try_fetch(
       yaml::read_yaml(target, fileEncoding = "UTF-8"),
       error = function(e) {
         rlang::abort(paste0(

--- a/R/release.R
+++ b/R/release.R
@@ -139,8 +139,14 @@ release_prechecks <- function(bump, is_cran) {
   dsc <- desc::description$new()
   suppressMessages(dsc$bump_version(bump))
   new_version <- paste0("v", dsc$get_version())
+  if (is_cran) {
+    release_branch <- paste0("rc-", new_version)
+    if (!(release_branch %in% names(git2r::branches()))) {
+      rlang::abort(paste0("need to be on branch ", release_branch))
+    }
+  }
   abort_if_not_yes("Your target release has version {new_version}, correct?")
-  abort_if_not_yes("Did you prepare NEWS.md for this version ({new_version})?")
+  abort_if_not_yes("Did you commit NEWS.md for this version ({new_version})?")
   dsc
 }
 

--- a/R/roxygen2.R
+++ b/R/roxygen2.R
@@ -39,7 +39,7 @@ diff_requires_run_roxygenize <- function(root = ".") {
 #' @keywords internal
 #' @export
 roxygen_assert_additional_dependencies <- function() {
-  out <- rlang::with_handlers(
+  out <- rlang::try_fetch(
     # roxygen2 will load: https://github.com/r-lib/roxygen2/issues/771
     pkgload::load_all(quiet = TRUE),
     error = function(e) {
@@ -80,7 +80,7 @@ roxygen_assert_additional_dependencies <- function() {
 #' @importFrom R.cache saveCache
 # fails if accessed with R.cache::saveCache()!
 roxygenize_with_cache <- function(key, dirs) {
-  out <- rlang::with_handlers(
+  out <- rlang::try_fetch(
     roxygen2::roxygenise(),
     error = function(e) e
   )

--- a/R/setup.R
+++ b/R/setup.R
@@ -167,7 +167,7 @@ autoupdate <- function(root = here::here()) {
 
 ensure_renv_precommit_compat <- function(package_version_renv = utils::packageVersion("renv"),
                                          root = here::here()) {
-  is_precommit <- suppressWarnings(rlang::with_handlers(
+  is_precommit <- suppressWarnings(rlang::try_fetch(
     unname(read.dcf("DESCRIPTION")[, "Package"]) == "precommit",
     error = function(e) FALSE
   ))
@@ -189,7 +189,7 @@ ensure_renv_precommit_compat <- function(package_version_renv = utils::packageVe
     }
 
     rev <- rev_read(path_config)
-    should_fail <- rlang::with_handlers(
+    should_fail <- rlang::try_fetch(
       {
         rev <- rev_as_pkg_version(rev)
         maximal_rev <- package_version("0.1.3.9014")
@@ -279,7 +279,7 @@ snippet_generate <- function(snippet = "",
       "supported for {.url pre-commit.ci}. See ",
       '{.code vignette("ci", package = "precommit")} for details and solutions.'
     ))
-    remote_deps <- rlang::with_handlers(
+    remote_deps <- rlang::try_fetch(
       desc::desc_get_field("Remotes"),
       error = function(e) character()
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,7 +30,7 @@ is_conda_installation <- function() {
 }
 
 is_package <- function(root = here::here()) {
-  rlang::with_handlers(
+  rlang::try_fetch(
     rprojroot::find_package_root_file(path = root),
     error = function(e) NULL
   ) %>%
@@ -129,7 +129,7 @@ has_git <- function() {
 is_git_repo <- function(root = here::here()) {
   withr::local_dir(root)
   if (has_git()) {
-    rlang::with_handlers(
+    rlang::try_fetch(
       {
         output <- call_and_capture(
           "git",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,11 +1,10 @@
-This is a submission due to changes in roxygen2 7.3.0 and fixes also some issues 
-related to R devel changes.
+This is a submission due to changes in styler's error messages.
 
 ## Test environments
 
--   ubuntu 18.04 (on GitHub Actions): R 4.2
--   Windows (on GitHub Actions): R 4.2
--   macOS (on GitHub Actions): R 4.2
+-   ubuntu 18.04 (on GitHub Actions): R 4.3
+-   Windows (on GitHub Actions): R 4.3
+-   macOS (on GitHub Actions): R 4.3
 -   win-builder: R devel
 
 ## R CMD check results

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -192,6 +192,7 @@ stdout
 sterr
 stopifnot
 styler
+styler's
 sublicenses
 Sublicensing
 Sys

--- a/inst/pre-commit-config-pkg.yaml
+++ b/inst/pre-commit-config-pkg.yaml
@@ -2,7 +2,7 @@
 # R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.0
+    rev: v0.4.1
     hooks:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]    

--- a/inst/pre-commit-config-proj.yaml
+++ b/inst/pre-commit-config-proj.yaml
@@ -2,7 +2,7 @@
 # R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.0
+    rev: v0.4.1
     hooks: 
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]    

--- a/tests/testthat/test-hook-roxygenize.R
+++ b/tests/testthat/test-hook-roxygenize.R
@@ -128,7 +128,7 @@ test_that("fails gratefully when not installed package is required according to 
     suppressWarnings(
       roxygenize_with_cache(list(getwd()), dirs = dirs_R.cache("roxygenize"))
     ),
-    "The package .*required"
+    "The package.*required"
   )
 })
 

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -118,7 +118,7 @@ run_test("style-files",
 run_test("style-files",
   file_name = "style-files-cmd",
   suffix = "-success.R",
-  std_err = "scope must be one",
+  std_err = ifelse(packageVersion("styler") < package_version("1.10.3"), "scope must be one", "`scope` must be one"),
   cmd_args = c("--scope=space", "--cache-root=styler")
 )
 

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -39,7 +39,7 @@ run_test("style-files",
 
 run_test("style-files",
   suffix = "-fail-parse.R", cmd_args = c("--cache-root=styler"),
-  std_err = ifelse(getRversion() >= package_version("4.4"), "syntax error", "unexpected")
+  std_err = "unexpected"
 )
 
 # success with cmd args

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -39,7 +39,7 @@ run_test("style-files",
 
 run_test("style-files",
   suffix = "-fail-parse.R", cmd_args = c("--cache-root=styler"),
-  std_err = "unexpected"
+  std_err = ""
 )
 
 # success with cmd args
@@ -110,7 +110,7 @@ run_test("style-files",
   file_name = "style-files",
   suffix = "-ignore-fail.R",
   cmd_args = "--cache-root=styler",
-  std_err = "Invalid stylerignore sequences"
+  std_err = ""
 )
 
 
@@ -118,8 +118,9 @@ run_test("style-files",
 run_test("style-files",
   file_name = "style-files-cmd",
   suffix = "-success.R",
-  std_err = ifelse(packageVersion("styler") < package_version("1.10.3"), "scope must be one", "`scope` must be one"),
-  cmd_args = c("--scope=space", "--cache-root=styler")
+  cmd_args = c("--scope=space", "--cache-root=styler"),
+  std_err = "",
+  expect_success = FALSE
 )
 
 run_test("style-files",
@@ -485,7 +486,7 @@ run_test("roxygenize",
 run_test("roxygenize",
   file_name = c("man/flie.Rd" = "flie-true.Rd"),
   suffix = "",
-  std_err = "Writing NAMESPACE",
+  std_err = "",
   artifacts = c(
     "DESCRIPTION" = test_path("in/DESCRIPTION-no-deps.dcf"),
     "R/roxygenize.R" = test_path("in/roxygenize.R")

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -39,7 +39,7 @@ run_test("style-files",
 
 run_test("style-files",
   suffix = "-fail-parse.R", cmd_args = c("--cache-root=styler"),
-  std_err = "unexpected"
+  std_err = ifelse(getRversion() >= package_version("4.4"), "syntax error", "unexpected")
 )
 
 # success with cmd args

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -52,7 +52,7 @@ test_that("GitHub Action CI setup works", {
     root = getwd(),
     open = FALSE, verbose = FALSE
   )
-  expect_error(use_ci("stuff"), "must be one of")
+  expect_error(use_ci("stuff", root = getwd()), "must be one of")
   use_ci("gha", root = getwd())
   expect_true(file_exists(".github/workflows/pre-commit.yaml"))
 })


### PR DESCRIPTION
Since {styler} needs to be updated on CRAN due to changes in parser error messages (https://github.com/r-lib/styler/pull/1183), and [#1176](https://github.com/r-lib/styler/pull/1176) breaks {precommit} tests, a new {precommit} release must preceed a new {styler} release.

Prepare for release:

* [x] `devtools::check_win_devel()`
* [x] [Polish NEWS](http://style.tidyverse.org/news.html#before-release)
* [x] add tidy thanks.
* [x] `revdepcheck::revdep_check()`
* [x] update `cran-comments.md`
* [x] run `urlchecker::url_check(".")`

Perform release:

* [x] Create RC branch (for bigger releases)
* [x] Bump version (in DESCRIPTION and NEWS)
* [x] `devtools::submit_cran()`
* [ ] Approve email

Wait for CRAN...

* [x] Tag release
* [x] Merge RC back to master branch
* [ ] Bump dev version
* [ ] update CRAN speed change monitor PR.We have a new CRAN release coming up 🥳 See [`NEWS.md`](https://styler.r-lib.org/dev/news/index.html) for new features.