### PR TITLE
Add parsable-roxygen hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -52,7 +52,7 @@
 -   id: parsable-roxygen
     name: parsable-roxygen
     description: check if roxygen comments in a .R file are parsable
-    entry: Rscript /inst/hooks/exported/parsable-roxygen.R
+    entry: Rscript inst/hooks/exported/parsable-roxygen.R
     language: r
     files: '\.[rR]$'
     minimum_pre_commit_version: "2.13.0"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -49,6 +49,13 @@
     language: r
     files: '\.[rR](md)?$'
     minimum_pre_commit_version: "2.13.0"
+-   id: parsable-roxygen
+    name: parsable-roxygen
+    description: check if roxygen comments in a .R file are parsable
+    entry: Rscript /inst/hooks/exported/parsable-roxygen.R
+    language: r
+    files: '\.[rR]$'
+    minimum_pre_commit_version: "2.13.0"
 -   id: readme-rmd-rendered
     name: readme-rmd-rendered
     description: make sure README.Rmd hasn't been edited more recently than `README.md`

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Roxygen: list(markdown = TRUE, roclets = c( "rd", "namespace", "collate",
     if (rlang::is_installed("pkgapi")) "pkgapi::api_roclet" else {
     warning("Please install r-lib/pkgapi to make sure the file API is kept
     up to date"); NULL} ) )
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 SystemRequirements: git
 Config/testthat/parallel: true
 Config/testthat/edition: 3

--- a/inst/hooks/exported/parsable-roxygen.R
+++ b/inst/hooks/exported/parsable-roxygen.R
@@ -11,6 +11,10 @@ Options:
 
 arguments <- precommit::precommit_docopt(doc)
 
+if (packageVersion("roxygen2") < package_version("7.3.0")) {
+  rlang::abort("You need at least version 7.3.0 of {roxygen2} to run this hook.")
+}
+
 out <- lapply(arguments$files, function(path) {
   tryCatch(
     # Capture any messages from roxygen2:::warn_roxy()

--- a/inst/hooks/exported/parsable-roxygen.R
+++ b/inst/hooks/exported/parsable-roxygen.R
@@ -2,15 +2,23 @@
 files <- commandArgs(trailing = TRUE)
 
 out <- lapply(files, function(path) {
+  
   tryCatch(
-    roxygen2::parse_file(path, env = NULL),
-    warning = function(w) {
-      cat(c("Roxygen commentary in file ", path, " is not parsable. Full context:\n"))
-      stop(conditionMessage(w), call. = FALSE)
-    },
+    # Capture any messages from roxygen2:::warn_roxy()
+    msg <- capture.output(
+      roxygen2::parse_file(path, env = NULL),
+      type = "message"
+    ),
+    
+    # In case we encounter a more general file parsing problem
     error = function(e) {
       cat(c("File ", path, " is not parsable. Full context:\n"))
       stop(conditionMessage(e), call. = FALSE)
     }
   )
+  
+  if (length(msg) > 0) {
+    cat(c("Roxygen commentary in file ", path, " is not parsable. Full context:\n"))
+    stop(paste0(msg, collapse = "\n"), call. = FALSE)
+  }
 })

--- a/inst/hooks/exported/parsable-roxygen.R
+++ b/inst/hooks/exported/parsable-roxygen.R
@@ -7,6 +7,10 @@ out <- lapply(files, function(path) {
     warning = function(w) {
       cat(c("Roxygen commentary in file ", path, " is not parsable. Full context:\n"))
       stop(conditionMessage(w), call. = FALSE)
+    },
+    error = function(e) {
+      cat(c("File ", path, " is not parsable. Full context:\n"))
+      stop(conditionMessage(e), call. = FALSE)
     }
   )
 })

--- a/inst/hooks/exported/parsable-roxygen.R
+++ b/inst/hooks/exported/parsable-roxygen.R
@@ -2,21 +2,20 @@
 files <- commandArgs(trailing = TRUE)
 
 out <- lapply(files, function(path) {
-  
   tryCatch(
     # Capture any messages from roxygen2:::warn_roxy()
     msg <- capture.output(
       roxygen2::parse_file(path, env = NULL),
       type = "message"
     ),
-    
+
     # In case we encounter a more general file parsing problem
     error = function(e) {
       cat(c("File ", path, " is not parsable. Full context:\n"))
       stop(conditionMessage(e), call. = FALSE)
     }
   )
-  
+
   if (length(msg) > 0) {
     cat(c("Roxygen commentary in file ", path, " is not parsable. Full context:\n"))
     stop(paste0(msg, collapse = "\n"), call. = FALSE)

--- a/inst/hooks/exported/parsable-roxygen.R
+++ b/inst/hooks/exported/parsable-roxygen.R
@@ -17,10 +17,11 @@ out <- lapply(arguments$files, function(path) {
     msg <- capture.output(
       roxygen2::parse_file(
         path,
-        env = if (isTRUE(arguments$no_eval))
+        env = if (isTRUE(arguments$no_eval)) {
           NULL
-        else
+        } else {
           roxygen2::env_file(path)
+        }
       ),
       type = "message"
     ),

--- a/inst/hooks/exported/parsable-roxygen.R
+++ b/inst/hooks/exported/parsable-roxygen.R
@@ -1,0 +1,12 @@
+#!/usr/bin/env Rscript
+files <- commandArgs(trailing = TRUE)
+
+out <- lapply(files, function(path) {
+  tryCatch(
+    roxygen2::parse_file(path, env = NULL),
+    warning = function(w) {
+      cat(c("Roxygen commentary in file ", path, " is not parsable. Full context:\n"))
+      stop(conditionMessage(w), call. = FALSE)
+    }
+  )
+})

--- a/inst/hooks/exported/parsable-roxygen.R
+++ b/inst/hooks/exported/parsable-roxygen.R
@@ -1,11 +1,27 @@
 #!/usr/bin/env Rscript
-files <- commandArgs(trailing = TRUE)
 
-out <- lapply(files, function(path) {
+"Check whether roxygen comments within files are valid
+Usage:
+  parsable-roxygen [--no-eval] <files>...
+
+Options:
+  --no-eval  Parse, but do not evaluate, file contents - this also suppresses evaluation of `@eval` tags
+
+" -> doc
+
+arguments <- precommit::precommit_docopt(doc)
+
+out <- lapply(arguments$files, function(path) {
   tryCatch(
     # Capture any messages from roxygen2:::warn_roxy()
     msg <- capture.output(
-      roxygen2::parse_file(path, env = NULL),
+      roxygen2::parse_file(
+        path,
+        env = if (isTRUE(arguments$no_eval))
+          NULL
+        else
+          roxygen2::env_file(path)
+      ),
       type = "message"
     ),
 

--- a/inst/hooks/exported/parsable-roxygen.R
+++ b/inst/hooks/exported/parsable-roxygen.R
@@ -2,10 +2,10 @@
 
 "Check whether roxygen comments within files are valid
 Usage:
-  parsable-roxygen [--no-eval] <files>...
+  parsable-roxygen [--eval] <files>...
 
 Options:
-  --no-eval  Parse, but do not evaluate, file contents - this also suppresses evaluation of `@eval` tags
+  --eval  Evaluate file contents after parsing - this is required if `@eval` tags must be evaluated
 
 " -> doc
 
@@ -17,10 +17,10 @@ out <- lapply(arguments$files, function(path) {
     msg <- capture.output(
       roxygen2::parse_file(
         path,
-        env = if (isTRUE(arguments$no_eval)) {
-          NULL
-        } else {
+        env = if (isTRUE(arguments$eval)) {
           roxygen2::env_file(path)
+        } else {
+          NULL
         }
       ),
       type = "message"

--- a/inst/pre-commit-hooks.yaml
+++ b/inst/pre-commit-hooks.yaml
@@ -52,7 +52,7 @@
 -   id: parsable-roxygen
     name: parsable-roxygen
     description: check if roxygen comments in a .R file are parsable
-    entry: Rscript /inst/hooks/exported/parsable-roxygen.R
+    entry: Rscript inst/hooks/exported/parsable-roxygen.R
     language: r
     files: '\.[rR]$'
     minimum_pre_commit_version: "2.13.0"

--- a/inst/pre-commit-hooks.yaml
+++ b/inst/pre-commit-hooks.yaml
@@ -49,6 +49,13 @@
     language: r
     files: '\.[rR](md)?$'
     minimum_pre_commit_version: "2.13.0"
+-   id: parsable-roxygen
+    name: parsable-roxygen
+    description: check if roxygen comments in a .R file are parsable
+    entry: Rscript /inst/hooks/exported/parsable-roxygen.R
+    language: r
+    files: '\.[rR]$'
+    minimum_pre_commit_version: "2.13.0"
 -   id: readme-rmd-rendered
     name: readme-rmd-rendered
     description: make sure README.Rmd hasn't been edited more recently than `README.md`

--- a/tests/testthat/in/parsable-roxygen-fail.R
+++ b/tests/testthat/in/parsable-roxygen-fail.R
@@ -1,0 +1,18 @@
+#' Some function
+#' 
+#' This function is great! But \code{oh dear, a missing brace...
+#' 
+#' And isn't that a multi-line example? We should probably use @examples...
+#' 
+#' @param x A parameter.
+#'
+#' @returns Invisible `NULL`.
+#' 
+#' @example
+#' some_function(10)
+#' some_function(11)
+#' 
+#' @export
+some_function <- function(x) {
+  x
+}

--- a/tests/testthat/in/parsable-roxygen-fail2.R
+++ b/tests/testthat/in/parsable-roxygen-fail2.R
@@ -1,0 +1,18 @@
+#' Some function
+#' 
+#' This function is great! But \code{oh dear, a missing brace...
+#' 
+#' And isn't that a multi-line example? We should probably use @examples...
+#' 
+#' @param x A parameter.
+#'
+#' @returns Invisible `NULL`.
+#' 
+#' @example
+#' some_function(10)
+#' some_function(11)
+#' 
+#' @export
+some_function <- function(x) {
+  (x
+}

--- a/tests/testthat/in/parsable-roxygen-fail2.R
+++ b/tests/testthat/in/parsable-roxygen-fail2.R
@@ -1,16 +1,4 @@
-#' Some function
-#' 
-#' This function is great! But \code{oh dear, a missing brace...
-#' 
-#' And isn't that a multi-line example? We should probably use @examples...
-#' 
-#' @param x A parameter.
-#'
-#' @returns Invisible `NULL`.
-#' 
-#' @example
-#' some_function(10)
-#' some_function(11)
+#' Minimal roxygen docs, but there's a problem with our R code!
 #' 
 #' @export
 some_function <- function(x) {

--- a/tests/testthat/in/parsable-roxygen-success.R
+++ b/tests/testthat/in/parsable-roxygen-success.R
@@ -13,3 +13,6 @@
 some_function <- function(x) {
   x
 }
+
+# To check whether code was evaluated
+print("A random print statement")

--- a/tests/testthat/in/parsable-roxygen-success.R
+++ b/tests/testthat/in/parsable-roxygen-success.R
@@ -1,0 +1,15 @@
+#' Some function
+#' 
+#' This function is great!
+#' 
+#' @param x A parameter.
+#'
+#' @returns Invisible `NULL`.
+#' 
+#' @examples
+#' some_function(10)
+#' 
+#' @export
+some_function <- function(x) {
+  x
+}

--- a/tests/testthat/reference-objects/pre-commit-config.yaml
+++ b/tests/testthat/reference-objects/pre-commit-config.yaml
@@ -59,6 +59,7 @@ repos:
           )$
     -   id: readme-rmd-rendered
     -   id: parsable-R
+    -   id: parsable-roxygen
     -   id: no-browser-statement
     -   id: no-print-statement
     -   id: no-debug-statement

--- a/tests/testthat/test-hook-parsable-roxygen.R
+++ b/tests/testthat/test-hook-parsable-roxygen.R
@@ -1,0 +1,13 @@
+run_test(
+  "parsable-roxygen",
+  suffix = "-success.R",
+  std_err = NULL
+)
+
+# failure
+run_test(
+  "parsable-roxygen",
+  suffix = "-fail.R",
+  std_out = "Full context",
+  std_err = "@description has mismatched braces or quotes"
+)

--- a/tests/testthat/test-hook-parsable-roxygen.R
+++ b/tests/testthat/test-hook-parsable-roxygen.R
@@ -1,21 +1,45 @@
+# success - code evaluated
 run_test(
   "parsable-roxygen",
   suffix = "-success.R",
-  std_err = NULL
+  std_out = "A random print statement",
+  std_err = NULL,
+  read_only = TRUE
 )
 
-# failure - roxygen not parsed
+# success - code not evaluated
+run_test(
+  "parsable-roxygen",
+  suffix = "-success.R",
+  cmd_args = "--no-eval",
+  std_out = NULL,
+  std_err = NULL,
+  read_only = TRUE
+)
+
+# failure - roxygen problem
 run_test(
   "parsable-roxygen",
   suffix = "-fail.R",
   std_out = "Roxygen commentary",
-  std_err = "@description has mismatched braces or quotes"
+  std_err = "@description has mismatched braces or quotes",
+  read_only = TRUE
 )
 
-# failure - R not parsed
+# failure - R problem
 run_test(
   "parsable-roxygen",
   suffix = "-fail2.R",
   std_out = "File ",
-  std_err = "unexpected '}'"
+  std_err = "unexpected '}'",
+  read_only = TRUE
+)
+
+
+run_test(
+  "parsable-roxygen",
+  suffix = "-fail4.R",
+  std_out = "File ",
+  std_err = "unexpected '}'",
+  read_only = TRUE
 )

--- a/tests/testthat/test-hook-parsable-roxygen.R
+++ b/tests/testthat/test-hook-parsable-roxygen.R
@@ -1,18 +1,18 @@
-# success - code evaluated
-run_test(
-  "parsable-roxygen",
-  suffix = "-success.R",
-  std_out = "A random print statement",
-  std_err = NULL,
-  read_only = TRUE
-)
-
 # success - code not evaluated
 run_test(
   "parsable-roxygen",
   suffix = "-success.R",
-  cmd_args = "--no-eval",
   std_out = NULL,
+  std_err = NULL,
+  read_only = TRUE
+)
+
+# success - code evaluated
+run_test(
+  "parsable-roxygen",
+  suffix = "-success.R",
+  cmd_args = "--eval",
+  std_out = "A random print statement",
   std_err = NULL,
   read_only = TRUE
 )
@@ -30,15 +30,6 @@ run_test(
 run_test(
   "parsable-roxygen",
   suffix = "-fail2.R",
-  std_out = "File ",
-  std_err = "unexpected '}'",
-  read_only = TRUE
-)
-
-
-run_test(
-  "parsable-roxygen",
-  suffix = "-fail4.R",
   std_out = "File ",
   std_err = "unexpected '}'",
   read_only = TRUE

--- a/tests/testthat/test-hook-parsable-roxygen.R
+++ b/tests/testthat/test-hook-parsable-roxygen.R
@@ -4,10 +4,18 @@ run_test(
   std_err = NULL
 )
 
-# failure
+# failure - roxygen not parsed
 run_test(
   "parsable-roxygen",
   suffix = "-fail.R",
-  std_out = "Full context",
+  std_out = "Roxygen commentary",
   std_err = "@description has mismatched braces or quotes"
+)
+
+# failure - R not parsed
+run_test(
+  "parsable-roxygen",
+  suffix = "-fail2.R",
+  std_out = "File ",
+  std_err = "unexpected '}'"
 )

--- a/vignettes/available-hooks.Rmd
+++ b/vignettes/available-hooks.Rmd
@@ -146,6 +146,22 @@ running `roxygen2::parse_file()` on them returns any messages.
 
 This hook does not modify files.
 
+**no eval**
+
+The `--no-eval` flag causes `roxygen2::parse_file()` to be run with`env = NULL`.
+This means each file will be parsed, but code will not be evaluated - neither
+any explicit code in the file, nor any `@eval` tags within roxygen comments.
+This can be useful if your files contain anything other than
+"simple object declarations" (e.g. [box modules](https://github.com/klmr/box/)
+containing `box::use()` calls).
+
+If `--no-eval` is set, inline code within roxygen comments (i.e. within
+backticks) _will_ still be evaluated, but in a new empty environment.
+
+      id: parsable-roxygen
+      args: [--no-eval]
+    
+
 ## `no-browser-statement`
 
 Guarantees you that you don't accidentally commit code with a

--- a/vignettes/available-hooks.Rmd
+++ b/vignettes/available-hooks.Rmd
@@ -142,7 +142,7 @@ This hook does not modify files.
 ## `parsable-roxygen`
 
 Checks if roxygen comments within your `.R` files are "valid" by checking if
-running `roxygen2::parse_file()` on them returns a warning.
+running `roxygen2::parse_file()` on them returns any messages.
 
 This hook does not modify files.
 

--- a/vignettes/available-hooks.Rmd
+++ b/vignettes/available-hooks.Rmd
@@ -153,15 +153,18 @@ This means each file will be parsed, but code will not be evaluated - neither
 any explicit code in the file, nor any `@eval` tags within roxygen comments.
 This can be useful if your files contain anything other than
 "simple object declarations" (e.g. [box modules](https://github.com/klmr/box/)
-containing `box::use()` calls).
+containing `box::use()` calls). When `--no-eval` is missing, this means dependencies 
+of the code to evaluate must be available for pre-commit. You may list these as 
+`additional_dependencies:` for the `parsable-roxygen` hook in 
+`.pre-commit-config.yaml`.
 
 Inline R code within roxygen comments (i.e. within backticks) is **not**
-evaluated by this hook, whether or not `--no-eval` is specified.
+evaluated by this hook, whether or not `--no-eval` is specified. You would need to run the `roxygenize` hook for that.
 
       id: parsable-roxygen
       args: [--no-eval]
     
-
+This hook was added in version 0.4.3.9000.
 ## `no-browser-statement`
 
 Guarantees you that you don't accidentally commit code with a

--- a/vignettes/available-hooks.Rmd
+++ b/vignettes/available-hooks.Rmd
@@ -146,25 +146,27 @@ running `roxygen2::parse_file()` on them returns any messages.
 
 This hook does not modify files.
 
-**no eval**
+**eval**
 
-The `--no-eval` flag causes `roxygen2::parse_file()` to be run with`env = NULL`.
-This means each file will be parsed, but code will not be evaluated - neither
+By default, each file will be parsed, but code will not be evaluated - neither
 any explicit code in the file, nor any `@eval` tags within roxygen comments.
-This can be useful if your files contain anything other than
-"simple object declarations" (e.g. [box modules](https://github.com/klmr/box/)
-containing `box::use()` calls). When `--no-eval` is missing, this means dependencies 
-of the code to evaluate must be available for pre-commit. You may list these as 
-`additional_dependencies:` for the `parsable-roxygen` hook in 
+
+If your commentary contains `@eval` tags which you would prefer to evaluate, you
+can specify the `--eval` flag, which will cause the file's code to be evaluated
+in an environment created by `roxygen2::env_file()`. Note that dependencies of
+the code to evaluate must be available for pre-commit. You may list these as
+`additional_dependencies:` for the `parsable-roxygen` hook in
 `.pre-commit-config.yaml`.
 
 Inline R code within roxygen comments (i.e. within backticks) is **not**
-evaluated by this hook, whether or not `--no-eval` is specified. You would need to run the `roxygenize` hook for that.
+evaluated by this hook, whether or not `--eval` is specified. You would need
+to run the `roxygenize` hook for that.
 
       id: parsable-roxygen
-      args: [--no-eval]
+      args: [--eval]
     
 This hook was added in version 0.4.3.9000.
+
 ## `no-browser-statement`
 
 Guarantees you that you don't accidentally commit code with a

--- a/vignettes/available-hooks.Rmd
+++ b/vignettes/available-hooks.Rmd
@@ -155,8 +155,8 @@ This can be useful if your files contain anything other than
 "simple object declarations" (e.g. [box modules](https://github.com/klmr/box/)
 containing `box::use()` calls).
 
-If `--no-eval` is set, inline code within roxygen comments (i.e. within
-backticks) _will_ still be evaluated, but in a new empty environment.
+Inline R code within roxygen comments (i.e. within backticks) is **not**
+evaluated by this hook, whether or not `--no-eval` is specified.
 
       id: parsable-roxygen
       args: [--no-eval]

--- a/vignettes/available-hooks.Rmd
+++ b/vignettes/available-hooks.Rmd
@@ -139,6 +139,13 @@ returns an error.
 
 This hook does not modify files.
 
+## `parsable-roxygen`
+
+Checks if roxygen comments within your `.R` files are "valid" by checking if
+running `roxygen2::parse_file()` on them returns a warning.
+
+This hook does not modify files.
+
 ## `no-browser-statement`
 
 Guarantees you that you don't accidentally commit code with a


### PR DESCRIPTION
As discussed in #562.

Things to note:

* Since `roxygen2::parse_file()` [does actually parse the file](https://github.com/r-lib/roxygen2/blob/c03a6711eea3f7dc16e55f0ab0babac9ff40d9ea/R/tokenize.R#L21), I think we have to allow this hook to fail in two ways:
  - If it catches a warning, it fails and explains that it's due to a roxygen error
  - If it catches an error, it fails in the same way as `parsable-R`
* I don't _think_ we need to actually evaluate the code though, hence [`roxygen2::parse_file(..., env = NULL)`](https://roxygen2.r-lib.org/reference/parse_package.html#arguments) - unless you can think of some reason why we _would_ need to evaluate?
* Do we need to do anything to ensure that {roxygen2} is available?
 
---

Closes #562.