### PR TITLE
Add --root argument to lintr hook

### DIFF
--- a/inst/hooks/exported/lintr.R
+++ b/inst/hooks/exported/lintr.R
@@ -3,14 +3,17 @@
 
 "Run lintr on R files during a precommit.
 Usage:
-  lintr [--warn_only] <files>...
+  lintr [--warn_only] [--root=<root_>] <files>...
 Options:
   --warn_only  Print lint warnings instead of blocking the commit. Should be
                used with `verbose: True` in `.pre-commit-config.yaml`.
                Otherwise, lints will never be shown to the user.
+  --root=<root_>  Path relative to the git root that contains the R package root [default: .].
 " -> doc
 
 arguments <- precommit::precommit_docopt(doc)
+arguments$files <- normalizePath(arguments$files) # because working directory changes to root
+setwd(normalizePath(arguments$root))
 
 lintr_staged <- grepl(
   "modified:.*\\.lintr", system2("git", "status", stdout = TRUE)


### PR DESCRIPTION
I have stumbled upon {box.linters} failing to run its checks as it relies on loading relative paths. Specifying a root directory with the newly-added `--root` flag solves this.


Edit: I just realized that it helped in a synthetic test—when invoked by hand. I cannot figure out how to pass absolute path to the repo via pre-commit's args. I tried `$PWD`, `pwd`, `$(git rev-parse --show-top-leell)`, but each was treated as a string and not expanded at all 🤔 