### PR TITLE
Update lintr hook and snippet_generate for lintr hook

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: precommit
 Title: Pre-Commit Hooks
-Version: 0.4.3.9018
+Version: 0.4.3.9019
 Author: Lorenz Walthert
 Maintainer: Lorenz Walthert <lorenz.walthert@icloud.com>
 Description: Useful git hooks for R building on top of the multi-language

--- a/R/setup.R
+++ b/R/setup.R
@@ -133,6 +133,15 @@ use_ci <- function(ci = getOption("precommit.ci", "native"),
       "proceed."
     ))
   }
+
+  if (length(grep("^ *- *id *: *lintr", config)) > 0) {
+    cli::cli_ul(paste0(
+      "It seems like you are using the lintr hook. This requires further ",
+      "edits in your {.code .pre-commit-config.yaml}, please run ",
+      "{.code precommit::snippet_generate('additional-deps-lintr')} to ",
+      "proceed."
+    ))
+  }
 }
 
 #' Auto-update your hooks
@@ -263,8 +272,17 @@ snippet_generate <- function(snippet = "additional-deps-roxygenize",
     "\n"
   ))
   deps <- desc::desc_get_deps()
-  hard_dependencies <- deps[(deps$type %in% c("Depends", "Imports")), "package"] %>%
+
+  # Add Suggests for lintr, so it works on vignettes, readme, etc.
+  dep_types <- if (snippet == "additional-deps-lintr") {
+    c("Depends", "Imports", "Suggests")
+  } else {
+    c("Depends", "Imports")
+  }
+
+  hard_dependencies <- deps[(deps$type %in% dep_types), "package"] %>%
     setdiff("R")
+
   if (length(hard_dependencies) < 1) {
     cli::cli_alert_success(paste0(
       "According to {.code DESCRIPTION}`, there are no hard dependencies of ",
@@ -277,10 +295,7 @@ snippet_generate <- function(snippet = "additional-deps-roxygenize",
     snippet_generator() %>%
     cat(sep = "")
   cat("\n")
-  cli::cli_ul(paste0(
-    "Replace the `id: roxygenize` key in `.pre-commit-config.yaml` with the ",
-    "above code."
-  ))
+
   cli::cli_alert_info(paste0(
     "Note that CI services like {.url pre-commit.ci} have build-time ",
     "restrictions and installing the above dependencies may exceed those, ",
@@ -334,6 +349,6 @@ snippet_generate_impl_additional_deps_lintr <- function(packages, with_version =
   ) %>%
     sort()
   paste0("    -   id: lintr
-        # lintr requires loading pkg -> add dependencies from DESCRIPTION
+        # lintr requires loading pkg -> add dependencies (incl. Suggests) from DESCRIPTION
         additional_dependencies:\n", out)
 }

--- a/R/setup.R
+++ b/R/setup.R
@@ -350,5 +350,6 @@ snippet_generate_impl_additional_deps_lintr <- function(packages, with_version =
     sort()
   paste0("    -   id: lintr
         # lintr requires loading pkg -> add dependencies (incl. Suggests) from DESCRIPTION
+        args: [--load_package]
         additional_dependencies:\n", out)
 }

--- a/inst/pre-commit-config-pkg.yaml
+++ b/inst/pre-commit-config-pkg.yaml
@@ -41,6 +41,7 @@ repos:
           data/.*|
           )$
     -   id: lintr
+        args: [--load_package]
     -   id: readme-rmd-rendered
     -   id: parsable-R
     -   id: no-browser-statement

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -40,6 +40,7 @@ test_that("snippet generation works for lintr", {
   expect_equal(out, paste0(
     "    -   id: lintr\n",
     "        # lintr requires loading pkg -> add dependencies (incl. Suggests) from DESCRIPTION\n",
+    "        args: [--load_package]\n",
     "        additional_dependencies:\n",
     "        -    testthat\n",
     ""

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -37,7 +37,13 @@ test_that("snippet generation works for lintr", {
     out <- capture_output(snippet_generate("additional-deps-lintr")),
     NA,
   )
-  expect_equal(out, "")
+  expect_equal(out, paste0(
+    "    -   id: lintr\n",
+    "        # lintr requires loading pkg -> add dependencies (incl. Suggests) from DESCRIPTION\n",
+    "        additional_dependencies:\n",
+    "        -    testthat\n",
+    ""
+  ))
   usethis::use_package("styler")
   expect_error(
     out <- capture_output(snippet_generate("additional-deps-lintr")),


### PR DESCRIPTION
This changes the `snippet_generate('additional-deps-lintr')` to also include suggested dependencies, so {lintr} works on vignettes, README, etc. Modifed default hook to include `args: [--load_package]` for lintr.

These changes prevents the default hooks from automatically failing when calling `use_precommit()` on a package, since {lintr} would fail if the package had any dependencies (or simply when the package calls its own function from another file).

Also removed an old print about roxygenize that always appeared.