### PR TITLE
Extend Rmd hook to qmd

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -58,10 +58,10 @@
     minimum_pre_commit_version: "2.13.0"
 -   id: readme-rmd-rendered
     name: readme-rmd-rendered
-    description: make sure README.Rmd hasn't been edited more recently than `README.md`
+    description: make sure README.Rmd or README.qmd hasn't been edited more recently than `README.md`
     entry: Rscript inst/hooks/exported/readme-rmd-rendered.R
     language: r
-    files: 'README\.[Rr]?md$'
+    files: 'README\.[RrQq]?md$'
     minimum_pre_commit_version: "2.13.0"
 -   id: codemeta-description-updated
     name: codemeta-description-updated

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: precommit
 Title: Pre-Commit Hooks
-Version: 0.4.3.9025
+Version: 0.4.3.9027
 Author: Lorenz Walthert
 Maintainer: Lorenz Walthert <lorenz.walthert@icloud.com>
 Description: Useful git hooks for R building on top of the multi-language

--- a/inst/hooks/exported/readme-rmd-rendered.R
+++ b/inst/hooks/exported/readme-rmd-rendered.R
@@ -1,4 +1,3 @@
-
 # Check for source files (case-insensitive)
 rmd_files <- list.files(pattern = "^README\\.[Rr]md$")
 qmd_files <- list.files(pattern = "^README\\.[Qq]md$")
@@ -13,7 +12,7 @@ if (length(rmd_files) == 1) {
 } else if (length(qmd_files) == 1) {
   source_file <- qmd_files
 } else {
-  quit(status=0)
+  quit(status = 0)
 }
 
 # Check if README.md exists and is in sync
@@ -21,21 +20,21 @@ if (file.exists("README.md")) {
   if (file.info("README.md")$mtime < file.info(source_file)$mtime) {
     rlang::abort(paste0("README.md is out of date; please re-knit ", source_file, "."))
   }
-  
+
   if (!nzchar(Sys.which("git"))) {
     rlang::abort("git not found on `$PATH`, hook can't be run.")
   }
-  
+
   # Get staged files
   file_names_staged <- system2(
     "git", c("diff --cached --name-only"),
     stdout = TRUE
   )
-  
+
   # Check that both source and output are staged together
   source_staged <- source_file %in% file_names_staged
   output_staged <- "README.md" %in% file_names_staged
-  
+
   if (!source_staged || !output_staged) {
     rlang::abort(paste(source_file, "and README.md must both be staged."))
   }

--- a/inst/hooks/exported/readme-rmd-rendered.R
+++ b/inst/hooks/exported/readme-rmd-rendered.R
@@ -1,17 +1,41 @@
-if (file.exists("README.Rmd") & file.exists("README.md")) {
-  if (file.info("README.md")$mtime < file.info("README.Rmd")$mtime) {
-    rlang::abort("README.md is out of date; please re-knit README.Rmd.")
+# Check for source files (case-insensitive)
+rmd_files <- list.files(pattern = "^README\\.[Rr]md$")
+qmd_files <- list.files(pattern = "^README\\.[Qq]md$")
+
+if (length(rmd_files) + length(qmd_files) > 1) {
+  rlang::abort("Multiple README source files found. Please use only one format (README.Rmd or README.qmd).")
+}
+
+# Determine which source file is present
+if (length(rmd_files) == 1) {
+  source_file <- rmd_files
+} else if (length(qmd_files) == 1) {
+  source_file <- qmd_files
+} else {
+  return()
+}
+
+# Check if README.md exists and is in sync
+if (file.exists("README.md")) {
+  if (file.info("README.md")$mtime < file.info(source_file)$mtime) {
+    rlang::abort(paste0("README.md is out of date; please re-knit ", source_file, "."))
   }
+  
   if (!nzchar(Sys.which("git"))) {
-    rlang::abort("git not found on `$PATH`, hook can't be ran.")
+    rlang::abort("git not found on `$PATH`, hook can't be run.")
   }
+  
+  # Get staged files
   file_names_staged <- system2(
     "git", c("diff --cached --name-only"),
     stdout = TRUE
   )
-  num_readmes <- length(grepl("^README\\.[R]?md$", file_names_staged))
-
-  if (num_readmes == 1) {
-    rlang::abort("README.Rmd and README.md should be both staged.")
+  
+  # Check that both source and output are staged together
+  source_staged <- source_file %in% file_names_staged
+  output_staged <- "README.md" %in% file_names_staged
+  
+  if (!source_staged || !output_staged) {
+    rlang::abort(paste(source_file, "and README.md must both be staged."))
   }
 }

--- a/inst/hooks/exported/readme-rmd-rendered.R
+++ b/inst/hooks/exported/readme-rmd-rendered.R
@@ -1,17 +1,36 @@
-if (file.exists("README.Rmd") & file.exists("README.md")) {
-  if (file.info("README.md")$mtime < file.info("README.Rmd")$mtime) {
-    rlang::abort("README.md is out of date; please re-knit README.Rmd.")
+renderable_files <- list.files(pattern = "^README\\.[QqRr]md$")
+renderable <- ""
+rmd <- grep("readme\\.rmd", renderable_files, ignore.case = TRUE, value = TRUE)
+qmd <- grep("readme\\.qmd", renderable_files, ignore.case = TRUE, value = TRUE)
+
+if (length(rmd) > 0) {
+  if (length(qmd) > 0) {
+    warning(paste0("Both ", rmd, " and ", qmd, " exist; ignoring ", qmd, "."))
+  }
+  renderable <- rmd[1]
+} else {
+  renderable <- qmd[1]
+}
+
+if (file.exists(renderable) && file.exists("README.md")) {
+  if (file.info("README.md")$mtime < file.info(renderable)$mtime) {
+    rlang::abort(paste0("README.md is out of date; please re-knit ", renderable, "."))
   }
   if (!nzchar(Sys.which("git"))) {
-    rlang::abort("git not found on `$PATH`, hook can't be ran.")
+    rlang::abort("git not found on `$PATH`, hook can't be run.")
   }
   file_names_staged <- system2(
     "git", c("diff --cached --name-only"),
     stdout = TRUE
   )
-  num_readmes <- length(grepl("^README\\.[R]?md$", file_names_staged))
+  # num_readmes <- length(grepl("^README\\.[R]?md$", file_names_staged))
+  staged_readmes <- grep("^README\\.[RrQq]?md$", file_names_staged, value = TRUE)
+  if (length(staged_readmes) > 0) {
+    rendered_staged <- any(grepl("README.md", staged_readmes, fixed = TRUE))
+    renderable_staged <- any(grepl(renderable, staged_readmes, fixed = TRUE))
 
-  if (num_readmes == 1) {
-    rlang::abort("README.Rmd and README.md should be both staged.")
+    if (!(rendered_staged && renderable_staged)) {
+      rlang::abort(paste(renderable, "and README.md should be both staged."))
+    }
   }
 }

--- a/inst/hooks/exported/readme-rmd-rendered.R
+++ b/inst/hooks/exported/readme-rmd-rendered.R
@@ -1,3 +1,4 @@
+
 # Check for source files (case-insensitive)
 rmd_files <- list.files(pattern = "^README\\.[Rr]md$")
 qmd_files <- list.files(pattern = "^README\\.[Qq]md$")
@@ -12,7 +13,7 @@ if (length(rmd_files) == 1) {
 } else if (length(qmd_files) == 1) {
   source_file <- qmd_files
 } else {
-  return()
+  quit(status=0)
 }
 
 # Check if README.md exists and is in sync

--- a/inst/pre-commit-hooks.yaml
+++ b/inst/pre-commit-hooks.yaml
@@ -58,10 +58,10 @@
     minimum_pre_commit_version: "2.13.0"
 -   id: readme-rmd-rendered
     name: readme-rmd-rendered
-    description: make sure README.Rmd hasn't been edited more recently than `README.md`
+    description: make sure README.Rmd or README.qmd hasn't been edited more recently than `README.md`
     entry: Rscript inst/hooks/exported/readme-rmd-rendered.R
     language: r
-    files: 'README\.[Rr]?md$'
+    files: 'README\.[RrQq]?md$'
     minimum_pre_commit_version: "2.13.0"
 -   id: codemeta-description-updated
     name: codemeta-description-updated

--- a/tests/testthat/in/README.qmd
+++ b/tests/testthat/in/README.qmd
@@ -1,0 +1,12 @@
+---
+format: gfm
+---
+
+# This is a readme
+
+```{r}
+knitr::opts_chunk$set(
+  fig.path = "man/figures/",
+  eval = FALSE
+)
+```

--- a/tests/testthat/test-hook-readme-rmd-rendered.R
+++ b/tests/testthat/test-hook-readme-rmd-rendered.R
@@ -33,7 +33,7 @@ if (has_git()) {
   run_test("readme-rmd-rendered",
     file_name = c("README.Rmd", "README.md", "README.qmd"),
     suffix = "",
-    std_err = 'Multiple README source files found',
+    std_err = "Multiple README source files found",
     std_out = NULL,
     file_transformer = function(files) {
       git_init()

--- a/tests/testthat/test-hook-readme-rmd-rendered.R
+++ b/tests/testthat/test-hook-readme-rmd-rendered.R
@@ -62,4 +62,55 @@ if (has_git()) {
       }
     )
   }
+
+  # qmd: out of date
+  run_test("readme-rmd-rendered",
+    file_name = c("README.md", "README.qmd"),
+    suffix = "",
+    std_err = "out of date",
+    std_out = NULL,
+    file_transformer = function(files) {
+      if (length(files) > 1) {
+        content_2 <- readLines(files[2])
+        Sys.sleep(2)
+        writeLines(content_2, files[2])
+        git_init()
+        git2r::add(path = files)
+      }
+      files
+    }
+  )
+
+  # only has qmd
+  run_test("readme-rmd-rendered",
+    file_name = "README.qmd",
+    suffix = "",
+    std_err = NULL,
+    std_out = NULL,
+    file_transformer = function(files) {
+      git_init()
+      git2r::add(path = files[1])
+      files
+    }
+  )
+
+  if (!on_windows_on_cran()) {
+    # qmd: only one file staged
+    run_test("readme-rmd-rendered",
+      file_name = c("README.qmd", "README.md"),
+      suffix = "",
+      std_err = "should be both staged",
+      std_out = NULL,
+      file_transformer = function(files) {
+        if (length(files) > 1) {
+          content_2 <- readLines(files[2])
+          Sys.sleep(2)
+          writeLines(content_2, files[2])
+          git_init()
+          git2r::add(path = files[1])
+        }
+        files
+      }
+    )
+  }
 }

--- a/tests/testthat/test-hook-readme-rmd-rendered.R
+++ b/tests/testthat/test-hook-readme-rmd-rendered.R
@@ -29,12 +29,25 @@ if (has_git()) {
       files
     }
   )
+  # only has Rmd
+  run_test("readme-rmd-rendered",
+    file_name = c("README.Rmd", "README.md", "README.qmd"),
+    suffix = "",
+    std_err = 'Multiple README source files found',
+    std_out = NULL,
+    file_transformer = function(files) {
+      git_init()
+      git2r::add(path = files[1])
+      files
+    }
+  )
+
   if (!on_windows_on_cran()) {
     # only one file staged
     run_test("readme-rmd-rendered",
       file_name = c("README.Rmd", "README.md"),
       suffix = "",
-      std_err = "should be both staged",
+      std_err = "must both be staged",
       std_out = NULL,
       file_transformer = function(files) {
         if (length(files) > 1) {
@@ -99,7 +112,7 @@ if (has_git()) {
     run_test("readme-rmd-rendered",
       file_name = c("README.qmd", "README.md"),
       suffix = "",
-      std_err = "should be both staged",
+      std_err = "must both be staged",
       std_out = NULL,
       file_transformer = function(files) {
         if (length(files) > 1) {

--- a/vignettes/available-hooks.Rmd
+++ b/vignettes/available-hooks.Rmd
@@ -136,8 +136,8 @@ This hook modifies files unless you specify `--dry=fail` (requires
 
 ## `readme-rmd-rendered`
 
-Make sure `README.Rmd` hasn't been edited more recently than
-`README.md`, i.e. remind you to render the `.Rmd` to `.md` before
+Make sure `README.Rmd` or `README.qmd` hasn't been edited more recently than
+`README.md`, i.e. remind you to render the `.Rmd` or `.qmd` to `.md` before
 committing.
 
 This hook does not modify files.


### PR DESCRIPTION
This extends the `readme-rme-rendered` hook such that it works in the same way for `README.qmd` as for `README.Rmd`.

If both `README.qmd` and `README.rmd` are present, the test is skipped with a warning.