### PR TITLE
Trigger build with old tag on pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
-# All available hooks: https://pre-commit.com/hooks.html
 # R specific hooks: https://github.com/lorenzwalthert/precommit
+# All available hooks: https://pre-commit.com/hooks.html
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
     rev: v0.4.3.9029

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # All available hooks: https://pre-commit.com/hooks.html
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.3.9029
+    rev: a62d29d
     hooks: 
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style, --cache-root=styler-perm]


### PR DESCRIPTION
Basically reverting https://github.com/lorenzwalthert/precommit/pull/683 and trigger new build. Actually a bit more, you can see the diff between the relevant tags: https://github.com/lorenzwalthert/precommit/compare/v0.4.3.9029...v0.4.3.9030